### PR TITLE
Change upstream of gcc-problem-matcher

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -94,7 +94,7 @@ jobs:
           CXX: aarch64-linux-gnu-g++-10
         run: cmake "$GITHUB_WORKSPACE" -DMELONDS_REPOSITORY_URL:STRING="${{ matrix.repo }}" -DMELONDS_REPOSITORY_TAG:STRING="${{ matrix.commit }}"
       - name: Install GCC problem matcher
-        uses: olemorud/gcc-problem-matcher@v1.0
+        uses: root-project/gcc-problem-matcher-improved@9d83f12b27a78210f0485fb188e08d94fa807a6d
       - name: Build
         working-directory: "${{ env.BUILD_DIR }}"
         run: make -j$(nproc --all)

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -37,7 +37,7 @@ jobs:
         working-directory: "${{ env.BUILD_DIR }}"
         run: cmake "$GITHUB_WORKSPACE" -DMELONDS_REPOSITORY_URL:STRING="${{ matrix.repo }}" -DMELONDS_REPOSITORY_TAG:STRING="${{ matrix.commit }}" -DCMAKE_OSX_ARCHITECTURES:STRING="arm64;x86_64"
       - name: Install GCC problem matcher
-        uses: olemorud/gcc-problem-matcher@v1.0
+        uses: root-project/gcc-problem-matcher-improved@9d83f12b27a78210f0485fb188e08d94fa807a6d
       - name: Build
         working-directory: "${{ env.BUILD_DIR }}"
         run: make -j$(sysctl -n hw.logicalcpu)

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -46,7 +46,7 @@ jobs:
         working-directory: "${{ env.BUILD_DIR }}"
         run: cmake "$GITHUB_WORKSPACE" -G"MinGW Makefiles" -DMELONDS_REPOSITORY_URL:STRING="${{ matrix.repo }}" -DMELONDS_REPOSITORY_TAG:STRING="${{ matrix.commit }}"
       - name: Install GCC problem matcher
-        uses: olemorud/gcc-problem-matcher@v1.0
+        uses: root-project/gcc-problem-matcher-improved@9d83f12b27a78210f0485fb188e08d94fa807a6d
       - name: Build
         working-directory: "${{ env.BUILD_DIR }}"
         run: mingw32-make -j$(nproc --all)


### PR DESCRIPTION
`olemorud/gcc-problem-matcher` will no longer be maitained and has to be made private because to allow the new upstream to use the same name. The new upstream is `root-project/gcc-problem-matcher-improved`. This PR changes the workflows to reflect this change. As I'm writing this the new upstream is not yet listed on the marketplace but this will be fixed soon.

see: https://github.com/root-project/gcc-problem-matcher-improved