### PR TITLE
Update pntr

### DIFF
--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -42,7 +42,7 @@ fetch_dependency("libretro-common" "https://github.com/libretro/libretro-common.
 fetch_dependency("embed-binaries" "https://github.com/andoalon/embed-binaries.git" "21f28ca")
 fetch_dependency(glm "https://github.com/g-truc/glm" "7882684")
 fetch_dependency(libslirp "https://github.com/JesseTG/libslirp-mirror.git" "44e7877")
-fetch_dependency(pntr "https://github.com/robloach/pntr.git" "1d7ba67")
+fetch_dependency(pntr "https://github.com/robloach/pntr.git" "22e752e")
 fetch_dependency(fmt "https://github.com/fmtlib/fmt.git" "10.1.1")
 fetch_dependency(yamc "https://github.com/yohhoy/yamc" "4e015a7")
 fetch_dependency(span-lite "https://github.com/martinmoene/span-lite" "bc08bf8")

--- a/src/libretro/message/error.cpp
+++ b/src/libretro/message/error.cpp
@@ -29,10 +29,10 @@
 constexpr int TITLE_FONT_HEIGHT = 20; // in pixels
 constexpr int BODY_FONT_HEIGHT = 18; // in pixels
 constexpr int MARGIN = 8; // in pixels
-constexpr pntr_color BACKGROUND_COLOR_TOP = {.b = 0xBC, .g = 0xB7, .r = 0xFA, .a = 0xFF}; // light pink
-constexpr pntr_color TEXT_COLOR_TOP = {.b = 0x19, .g = 0x0F, .r = 0xD7, .a = 0xFF}; // dark red
-constexpr pntr_color BACKGROUND_COLOR_BOTTOM = {.b = 0x36, .g = 0x7D, .r = 0x63, .a = 0xFF}; // dark green
-constexpr pntr_color TEXT_COLOR_BOTTOM = {.b = 0x98, .g = 0xE5, .r = 0xE7, .a = 0xFF}; // light green
+constexpr pntr_color BACKGROUND_COLOR_TOP = {.rgba = {.b = 0xBC, .g = 0xB7, .r = 0xFA, .a = 0xFF}}; // light pink
+constexpr pntr_color TEXT_COLOR_TOP = {.rgba = {.b = 0x19, .g = 0x0F, .r = 0xD7, .a = 0xFF}}; // dark red
+constexpr pntr_color BACKGROUND_COLOR_BOTTOM = {.rgba = {.b = 0x36, .g = 0x7D, .r = 0x63, .a = 0xFF}}; // dark green
+constexpr pntr_color TEXT_COLOR_BOTTOM = {.rgba = {.b = 0x98, .g = 0xE5, .r = 0xE7, .a = 0xFF}}; // light green
 
 static constexpr const char* const ERROR_TITLE = "Oh no! melonDS DS couldn't start...";
 static constexpr const char* const SOLUTION_TITLE = "Here's what you can do:";


### PR DESCRIPTION
In order to meet C99 support, the union required a name, so it's named .rgba . I'm not sure this is the best approach. May be better to assign the values in the constructor with pntr_new_color() so that it doesn't get too funky.

The following code block could be used to use pntr_new_color() via the defines.

``` c
#define BACKGROUND_COLOR_TOP pntr_new_color(0xFA, 0xB7, 0xBC, 0xFF) // light pink
#define TEXT_COLOR_TOP pntr_new_color(0xD7, 0x0F, 0x19, 0xFF) // dark red
#define BACKGROUND_COLOR_BOTTOM pntr_new_color(0x63, 0x7D, 0x36, 0xFF) // dark green
#define TEXT_COLOR_BOTTOM pntr_new_color(0xE7, 0xE5, 0x98, 0xFF) // light green
```

Working fine:
![Screenshot at 2024-01-14 13-38-42](https://github.com/JesseTG/melonds-ds/assets/25086/767f55a6-1331-47e4-bdd3-674c783153e1)

