### PR TITLE
ci: Update to actions/checkout@v4

### DIFF
--- a/.github/actions/test-deps/action.yml
+++ b/.github/actions/test-deps/action.yml
@@ -55,7 +55,7 @@ runs:
         7z x -o"$Env:ProgramFiles" RetroArch.7z
 
     - name: Download Test Files
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: "${{ inputs.testfile-repo }}"
         token: "${{ inputs.testfile-repo-token }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
         shell: ${{ inputs.shell }}
     steps:
       - name: Check Out Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install GCC Problem Matcher
         uses: root-project/gcc-problem-matcher-improved@9d83f12b27a78210f0485fb188e08d94fa807a6d

--- a/.github/workflows/check-urls.yaml
+++ b/.github/workflows/check-urls.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate URLs
         uses: urlstechie/urlchecker-action@0.0.34

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # To ensure we have all tags
       - name: Get Latest Changelog Version
@@ -231,7 +231,7 @@ jobs:
 
       - name: Checkout libretro-super
         if: "${{ steps.changelog.outputs.version != steps.newest-tag.outputs.version }}"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "libretro/libretro-super"
           path: libretro-super

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
         shell: ${{ inputs.shell }}
     steps:
       - name: Check Out Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         uses: ./.github/actions/test-deps


### PR DESCRIPTION
This updates https://github.com/actions/checkout to 4.x in hopes that the missing `token` input argument gets fixed.