### PR TITLE
gitignore: Add CMake's "build" directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ fileList*.txt
 
 # Build System
 artifact
+build
 melondsds-LICENSE.txt
 melondsds_libretro.info
 out.txt


### PR DESCRIPTION
`build` is often considered the default build directory for cmake. This change adds "build" to the gitignore file so that it doesn't appear in git diffs.