### PR TITLE
Fix build for GLES < 3.2

### DIFF
--- a/src/libretro/render/opengl.hpp
+++ b/src/libretro/render/opengl.hpp
@@ -28,6 +28,10 @@
 #include <glm/vec2.hpp>
 #include <glm/vec4.hpp>
 
+#if !defined(HAVE_OPENGL) && !defined(HAVE_OPENGLES32)
+#   define glObjectLabel
+#endif
+
 namespace MelonDsDs {
     using glm::vec2;
     using glm::vec4;


### PR DESCRIPTION
If you try to build with `-DENABLE_OPENGL=ON -DOPENGL_PROFILE=OpenGLES3` you'll get several 
`error: 'glObjectLabel' was not declared in this scope; did you mean 'glObjectLabelKHR'?`

It appears only in 3.2
```bash
$ grep glObjectLabel /usr/include/GLES3/*
/usr/include/GLES3/gl32.h:GL_APICALL void GL_APIENTRY glObjectLabel (GLenum identifier, GLuint name, GLsizei length, const GLchar *label);
```

As it used only for debug purposes I just dummy it out in that case. 
Maybe need to do something better like using `glObjectLabelKHR` (defined in `GLES2/gl2ext.h`) as supposed.