### PR TITLE
Emulated local Wi-Fi multiplayer support (2 players max)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ you can set its DNS address
 from within the emulated console's Wi-Fi settings menu.
 
 > [!NOTE]
-> Do not confuse this with local multiplayer.
-> melonDS DS does not support emulating local wireless
-> at this time.
+> Do not confuse this with local multiplayer,
+> which does not require access to the Internet
+> and is implemented using libretro's netplay API.
 
 ## Homebrew Save Data
 
@@ -191,11 +191,6 @@ These features have not yet been implemented in standalone [melonDS][melonds],
 or they haven't been integrated into melonDS DS.
 If you want to see them, ask how you can get involved!
 
-- **Local Wireless:**
-  Upstream melonDS supports emulating local wireless multiplayer
-  (e.g. Multi-Card Play, Download Play) with multiple instances of melonDS on the same computer
-  or on the same network.
-  This feature is not yet integrated into melonDS DS.
 - **Homebrew Savestates:**
   melonDS has limited support for taking savestates of homebrew games,
   as the virtual SD card is not included in savestate data.

--- a/src/libretro/CMakeLists.txt
+++ b/src/libretro/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.20)
-# 3.20 required for detecting endianness
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/src/libretro/CMakeLists.txt
+++ b/src/libretro/CMakeLists.txt
@@ -278,10 +278,6 @@ if (HAVE_NETWORKING)
     endif()
 endif()
 
-if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
-    target_compile_definitions(melondsds_libretro PRIVATE BIG_ENDIAN)
-endif()
-
 if (TRACY_ENABLE)
     target_link_libraries(melondsds_libretro PUBLIC TracyClient)
     target_include_directories(melondsds_libretro SYSTEM PUBLIC TracyClient)

--- a/src/libretro/CMakeLists.txt
+++ b/src/libretro/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.20)
+# 3.20 required for detecting endianness
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -60,6 +62,8 @@ add_library(melondsds_libretro ${LIBRARY_TYPE}
     net/pcap.hpp
     net/net.cpp
     net/net.hpp
+    net/mp.cpp
+    net/mp.hpp
     platform/file.cpp
     platform/lan.cpp
     platform/mp.cpp
@@ -272,6 +276,10 @@ if (HAVE_NETWORKING)
     if (WIN32)
         target_link_libraries(melondsds_libretro PRIVATE ws2_32 iphlpapi)
     endif()
+endif()
+
+if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+    target_compile_definitions(melondsds_libretro PRIVATE BIG_ENDIAN)
 endif()
 
 if (TRACY_ENABLE)

--- a/src/libretro/core/core.cpp
+++ b/src/libretro/core/core.cpp
@@ -21,7 +21,6 @@
 #include <GPU3D_OpenGL.h>
 #include <GPU3D_Soft.h>
 
-#include <libretro.h>
 #include <retro_assert.h>
 
 #include <NDS.h>

--- a/src/libretro/core/core.hpp
+++ b/src/libretro/core/core.hpp
@@ -93,7 +93,7 @@ namespace MelonDsDs {
         void DestroyRenderState();
         int LanSendPacket(std::span<std::byte> data) noexcept;
         int LanRecvPacket(uint8_t* data) noexcept;
-        
+
         void MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive);
         void MpPacketReceived(const void *buf, size_t len);
         void MpStopped();

--- a/src/libretro/core/core.hpp
+++ b/src/libretro/core/core.hpp
@@ -97,9 +97,10 @@ namespace MelonDsDs {
         void MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive);
         void MpPacketReceived(const void *buf, size_t len);
         void MpStopped();
-        void MpSendPacket(Packet p);
+        bool MpSendPacket(Packet p);
         std::optional<Packet> MpNextPacket();
         std::optional<Packet> MpNextPacketBlock();
+        bool MpActive();
 
         void WriteNdsSave(std::span<const std::byte> savedata, uint32_t writeoffset, uint32_t writelen) noexcept;
         void WriteGbaSave(std::span<const std::byte> savedata, uint32_t writeoffset, uint32_t writelen) noexcept;

--- a/src/libretro/core/core.hpp
+++ b/src/libretro/core/core.hpp
@@ -94,13 +94,13 @@ namespace MelonDsDs {
         int LanSendPacket(std::span<std::byte> data) noexcept;
         int LanRecvPacket(uint8_t* data) noexcept;
 
-        void MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive);
-        void MpPacketReceived(const void *buf, size_t len);
-        void MpStopped();
-        bool MpSendPacket(Packet p);
-        std::optional<Packet> MpNextPacket();
-        std::optional<Packet> MpNextPacketBlock();
-        bool MpActive();
+        void MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive) noexcept;
+        void MpPacketReceived(const void *buf, size_t len) noexcept;
+        void MpStopped() noexcept;
+        bool MpSendPacket(const Packet &p) const noexcept;
+        std::optional<Packet> MpNextPacket() noexcept;
+        std::optional<Packet> MpNextPacketBlock() noexcept;
+        bool MpActive() const noexcept;
 
         void WriteNdsSave(std::span<const std::byte> savedata, uint32_t writeoffset, uint32_t writelen) noexcept;
         void WriteGbaSave(std::span<const std::byte> savedata, uint32_t writeoffset, uint32_t writelen) noexcept;

--- a/src/libretro/core/core.hpp
+++ b/src/libretro/core/core.hpp
@@ -18,6 +18,7 @@
 #define MELONDSDS_CORE_HPP
 
 #include <cstddef>
+#include <libretro.h>
 #include <memory>
 #include <regex>
 
@@ -33,6 +34,7 @@
 #include "../PlatformOGLPrivate.h"
 #include "../sram.hpp"
 #include "net/net.hpp"
+#include "net/mp.hpp"
 #include "std/span.hpp"
 
 struct retro_game_info;
@@ -91,6 +93,13 @@ namespace MelonDsDs {
         void DestroyRenderState();
         int LanSendPacket(std::span<std::byte> data) noexcept;
         int LanRecvPacket(uint8_t* data) noexcept;
+        
+        void MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive);
+        void MpPacketReceived(const void *buf, size_t len);
+        void MpStopped();
+        void MpSendPacket(Packet p);
+        std::optional<Packet> MpNextPacket();
+        std::optional<Packet> MpNextPacketBlock();
 
         void WriteNdsSave(std::span<const std::byte> savedata, uint32_t writeoffset, uint32_t writelen) noexcept;
         void WriteGbaSave(std::span<const std::byte> savedata, uint32_t writeoffset, uint32_t writelen) noexcept;
@@ -142,6 +151,7 @@ namespace MelonDsDs {
         InputState _inputState {};
         MicrophoneState _micState {};
         RenderStateWrapper _renderState {};
+        MpState _mpState {};
         std::optional<retro::GameInfo> _ndsInfo = std::nullopt;
         std::optional<retro::GameInfo> _gbaInfo = std::nullopt;
         std::optional<retro::GameInfo> _gbaSaveInfo = std::nullopt;

--- a/src/libretro/core/core.hpp
+++ b/src/libretro/core/core.hpp
@@ -95,9 +95,9 @@ namespace MelonDsDs {
         int LanRecvPacket(uint8_t* data) noexcept;
 
         void MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive) noexcept;
-        void MpPacketReceived(const void *buf, size_t len) noexcept;
+        void MpPacketReceived(const void *buf, size_t len, uint16_t client_id) noexcept;
         void MpStopped() noexcept;
-        bool MpSendPacket(const Packet &p) const noexcept;
+        bool MpSendPacket(const Packet &p) noexcept;
         std::optional<Packet> MpNextPacket() noexcept;
         std::optional<Packet> MpNextPacketBlock() noexcept;
         bool MpActive() const noexcept;

--- a/src/libretro/environment.cpp
+++ b/src/libretro/environment.cpp
@@ -718,7 +718,6 @@ void retro::env::deinit() noexcept {
     _supportsNoGameMode = false;
     _lastFrameTime = std::nullopt;
     _message_interface_version = UINT_MAX;
-    MelonDsDs::MpStopped();
 }
 
 [[gnu::hot]] static void FrameTimeCallback(retro_usec_t usec) noexcept {

--- a/src/libretro/environment.cpp
+++ b/src/libretro/environment.cpp
@@ -737,7 +737,7 @@ PUBLIC_SYMBOL void retro_set_environment(retro_environment_t cb) {
     // TODO: Handle potential errors with each environment call below
     retro_core_options_update_display_callback update_display_cb {MelonDsDs::UpdateOptionVisibility};
     environment(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK, &update_display_cb);
-    
+
     retro_netpacket_callback netpacket_callback {
         .start = &MelonDsDs::MpStarted,
         .receive = &MelonDsDs::MpReceived,

--- a/src/libretro/environment.cpp
+++ b/src/libretro/environment.cpp
@@ -39,6 +39,7 @@
 #include "libretro.hpp"
 #include "config/config.hpp"
 #include "core/test.hpp"
+#include "net/mp.hpp"
 #include "tracy.hpp"
 #include "version.hpp"
 
@@ -736,6 +737,13 @@ PUBLIC_SYMBOL void retro_set_environment(retro_environment_t cb) {
     // TODO: Handle potential errors with each environment call below
     retro_core_options_update_display_callback update_display_cb {MelonDsDs::UpdateOptionVisibility};
     environment(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK, &update_display_cb);
+    
+    retro_netpacket_callback netpacket_callback {
+        .start = &MelonDsDs::MpStarted,
+        .receive = &MelonDsDs::MpReceived,
+        .stop = &MelonDsDs::MpStopped,
+    };
+    environment(RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE, &netpacket_callback);
 
     environment(RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE, (void*) MelonDsDs::content_overrides);
     environment(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*) MelonDsDs::ports);

--- a/src/libretro/environment.cpp
+++ b/src/libretro/environment.cpp
@@ -79,8 +79,6 @@ namespace retro {
 
     static char _sysSubdir[PATH_LENGTH] {};
     static size_t _sysSubdirLength = 0;
-    
-    static int64_t _usTime = 0;
 
     static retro_rumble_interface _rumble {};
 
@@ -694,14 +692,6 @@ bool retro::set_rumble_state(unsigned port, uint16_t strength) noexcept {
         _rumble.set_rumble_state(port, RETRO_RUMBLE_WEAK, strength);
 }
 
-int64_t retro::get_us_time() {
-    return _usTime;
-}
-
-PUBLIC_SYMBOL void us_time_callback(retro_usec_t deltaTime) {
-    retro::_usTime += deltaTime;
-}
-
 void retro::env::init() noexcept {
     ZoneScopedN(TracyFunction);
     retro_assert(_environment != nullptr);
@@ -721,7 +711,6 @@ void retro::env::deinit() noexcept {
     _saveSubdirLength = 0;
     _sysDirLength = 0;
     _sysSubdirLength = 0;
-    _usTime = 0;
     _environment = nullptr;
     _log = nullptr;
     _supports_bitmasks = false;
@@ -749,12 +738,6 @@ PUBLIC_SYMBOL void retro_set_environment(retro_environment_t cb) {
     // TODO: Handle potential errors with each environment call below
     retro_core_options_update_display_callback update_display_cb {MelonDsDs::UpdateOptionVisibility};
     environment(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK, &update_display_cb);
-
-    /*struct retro_frame_time_callback frame_time_cb = {
-        .callback = &us_time_callback,
-        .reference = 16667,
-    };
-    bool hasTime = environment(RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK, &frame_time_cb);*/
 
     retro_netpacket_callback netpacket_callback {
         .start = &MelonDsDs::MpStarted,

--- a/src/libretro/environment.hpp
+++ b/src/libretro/environment.hpp
@@ -125,6 +125,8 @@ namespace retro {
     std::optional<std::string_view> get_system_subdirectory() noexcept;
     std::optional<std::string> get_system_path(std::string_view name) noexcept;
     std::optional<std::string> get_system_subdir_path(std::string_view name) noexcept;
+    
+    int64_t get_us_time();
 
     namespace env {
         void init() noexcept;

--- a/src/libretro/environment.hpp
+++ b/src/libretro/environment.hpp
@@ -125,8 +125,6 @@ namespace retro {
     std::optional<std::string_view> get_system_subdirectory() noexcept;
     std::optional<std::string> get_system_path(std::string_view name) noexcept;
     std::optional<std::string> get_system_subdir_path(std::string_view name) noexcept;
-    
-    int64_t get_us_time();
 
     namespace env {
         void init() noexcept;

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -361,6 +361,10 @@ int Platform::MP_SendCmd(u8* data, int len, u64 timestamp, void*) {
 }
 
 int Platform::MP_SendReply(u8 *data, int len, u64 timestamp, u16 aid, void*) {
+    // aid is always less than 16,
+    // otherwise sending a 16-bit wide aidmask in RecvReplies wouldn't make sense,
+    // and neither would this line[1] from melonDS itself.
+    // [1] https://github.com/melonDS-emu/melonDS/blob/817b409ec893fb0b2b745ee18feced08706419de/src/net/LAN.cpp#L1074
     retro_assert(aid < 16);
     return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, aid, true)) ? len : 0;
 }

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -30,7 +30,9 @@
 #include <compat/strl.h>
 #include <file/file_path.h>
 #include <libretro.h>
+#define RARCH_INTERNAL
 #include <retro_assert.h>
+#undef RARCH_INTERNAL
 #include <retro_miscellaneous.h>
 
 #undef isnan
@@ -63,6 +65,41 @@ namespace MelonDsDs {
     CoreState& Core = *reinterpret_cast<CoreState*>(CoreStateBuffer.data());
 }
 
+void testEqual(const char *mensagem, uint8_t a, uint8_t b) {
+    if (a != b) {
+        retro::error("valores de {} divergem: {} nao e igual a {}", mensagem, a, b);
+    }
+}
+
+void printBuf(const char *buf, size_t len) {
+    const uint8_t *bufa = (const uint8_t *)buf;
+    printf("{ ");
+    for(int i = 0; i < len; i++) {
+        printf("%02X, ", bufa[i]);
+    }
+    printf(" }\n");
+}
+
+void testPacket() {
+    const char *teste = "olá, tudo bem?";
+    MelonDsDs::Packet p{teste, strlen(teste) + 1, 50, 2, true};
+    std::vector<uint8_t> bufBytes = p.ToBuf();
+    const char *buf = (const char *)bufBytes.data();
+    MelonDsDs::Packet np = MelonDsDs::Packet::parsePk(buf, p.Length() + MelonDsDs::HeaderSize);
+
+    retro_assert(np.Length() == p.Length() && p.Length() == strlen(teste) + 1);
+    testEqual("aid dos pacotes", p.Aid(), np.Aid());
+    testEqual("aid esperada", p.Aid(), 2);
+    retro_assert(p.Aid() == np.Aid() && p.Aid() == 2);
+    retro_assert(p.IsReply() == np.IsReply() && p.IsReply());
+    retro_assert(p.Timestamp() == np.Timestamp() && p.Timestamp() == 50);
+    retro_assert(strcmp((const char *)p.Data(), (const char *)np.Data()) == 0 && strcmp((const char *)p.Data(), teste) == 0);
+    std::vector<uint8_t> npBytes = np.ToBuf();
+    printBuf(buf, p.Length() + MelonDsDs::HeaderSize);
+    printBuf((const char *)npBytes.data(), np.Length() + MelonDsDs::HeaderSize);
+    retro_assert(memcmp(buf, (const char *)npBytes.data(), p.Length() + MelonDsDs::HeaderSize) == 0);
+}
+
 PUBLIC_SYMBOL void retro_init(void) {
 #ifdef HAVE_TRACY
     tracy::StartupProfiler();
@@ -79,6 +116,7 @@ PUBLIC_SYMBOL void retro_init(void) {
     memset(MelonDsDs::CoreStateBuffer.data(), 0, MelonDsDs::CoreStateBuffer.size());
     new(&MelonDsDs::CoreStateBuffer) MelonDsDs::CoreState(); // placement-new the CoreState
     retro_assert(MelonDsDs::Core.IsInitialized());
+    testPacket();
 }
 
 PUBLIC_SYMBOL bool retro_load_game(const struct retro_game_info *info) {
@@ -338,49 +376,54 @@ extern "C" void MelonDsDs::MpStopped() {
     MelonDsDs::Core.MpStopped();
 }
 
-int Platform::MP_SendPacket(u8* data, int len, u64 timestamp, void*) {
-    MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false));
-    return len;
-}
-
 int DeconstructPacket(u8 *data, u64 *timestamp, std::optional<MelonDsDs::Packet> o_p) {
     if (!o_p.has_value()) {
         return 0;
     }
     MelonDsDs::Packet p = o_p.value();
-    memcpy(data, p.ToBuf(), p.Length());
+    memcpy(data, p.Data(), p.Length());
     *timestamp = p.Timestamp();
     return p.Length();
 }
 
+int Platform::MP_SendPacket(u8* data, int len, u64 timestamp, void*) {
+    retro::debug("sending command with timestamp {}", timestamp);
+    return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false)) ? len : 0;
+}
+
 int Platform::MP_RecvPacket(u8* data, u64* timestamp, void*) {
+    //retro::debug("receiving packet");
     std::optional<MelonDsDs::Packet> o_p = MelonDsDs::Core.MpNextPacket();
     return DeconstructPacket(data, timestamp, o_p);
 }
 
 int Platform::MP_SendCmd(u8* data, int len, u64 timestamp, void*) {
-    MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false));
-    return len;
+    retro::debug("sending command with timestamp {}", timestamp);
+    return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false)) ? len : 0;
 }
 
 int Platform::MP_SendReply(u8 *data, int len, u64 timestamp, u16 aid, void*) {
     retro_assert(aid < 16);
-    MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, aid, true));
-    return len;
+    retro::debug("sending reply to aid {} with timestamp {}", timestamp, aid);
+    return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, aid, true)) ? len : 0;
 }
 
 int Platform::MP_SendAck(u8* data, int len, u64 timestamp, void*) {
-    MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false));
-    return len;
+    retro::debug("sending ack with timestamp {}", timestamp);
+    return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false)) ? len : 0;
 }
 
 int Platform::MP_RecvHostPacket(u8* data, u64 * timestamp, void*) {
+    retro::debug("receiving host packet");
     std::optional<MelonDsDs::Packet> o_p = MelonDsDs::Core.MpNextPacketBlock();
     return DeconstructPacket(data, timestamp, o_p);
 }
 
 u16 Platform::MP_RecvReplies(u8* packets, u64 timestamp, u16 aidmask, void*) {
-    retro::info("RecvReplies called with mask {}", ((int)aidmask));
+    retro::debug("RecvReplies called with mask {}", ((int)aidmask));
+    if(!MelonDsDs::Core.MpActive()) {
+        return 0;
+    }
     u16 ret = 0;
     int loops = 0;
     while(ret != aidmask) {
@@ -393,7 +436,7 @@ u16 Platform::MP_RecvReplies(u8* packets, u64 timestamp, u16 aidmask, void*) {
             continue;
         }
         ret |= 1<<p.Aid();
-        memcpy(&packets[(p.Aid()-1)*1024], p.ToBuf(), p.Length());
+        memcpy(&packets[(p.Aid()-1)*1024], p.Data(), p.Length());
         loops++;
     }
     return ret;

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -432,6 +432,9 @@ u16 Platform::MP_RecvReplies(u8* packets, u64 timestamp, u16 aidmask, void*) {
             return ret;
         }
         MelonDsDs::Packet p = o_p.value();
+        if(p.Timestamp() < (timestamp - 32)) {
+            continue;
+        }
         if(!p.IsReply()) {
             continue;
         }

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -24,7 +24,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <fmt/base.h>
 #include <memory>
 #include <span>
 

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -30,9 +30,7 @@
 #include <compat/strl.h>
 #include <file/file_path.h>
 #include <libretro.h>
-#define RARCH_INTERNAL
 #include <retro_assert.h>
-#undef RARCH_INTERNAL
 #include <retro_miscellaneous.h>
 
 #undef isnan
@@ -65,41 +63,6 @@ namespace MelonDsDs {
     CoreState& Core = *reinterpret_cast<CoreState*>(CoreStateBuffer.data());
 }
 
-void testEqual(const char *mensagem, uint8_t a, uint8_t b) {
-    if (a != b) {
-        retro::error("valores de {} divergem: {} nao e igual a {}", mensagem, a, b);
-    }
-}
-
-void printBuf(const char *buf, size_t len) {
-    const uint8_t *bufa = (const uint8_t *)buf;
-    printf("{ ");
-    for(int i = 0; i < len; i++) {
-        printf("%02X, ", bufa[i]);
-    }
-    printf(" }\n");
-}
-
-void testPacket() {
-    const char *teste = "olá, tudo bem?";
-    MelonDsDs::Packet p{teste, strlen(teste) + 1, 50, 2, true};
-    std::vector<uint8_t> bufBytes = p.ToBuf();
-    const char *buf = (const char *)bufBytes.data();
-    MelonDsDs::Packet np = MelonDsDs::Packet::parsePk(buf, p.Length() + MelonDsDs::HeaderSize);
-
-    retro_assert(np.Length() == p.Length() && p.Length() == strlen(teste) + 1);
-    testEqual("aid dos pacotes", p.Aid(), np.Aid());
-    testEqual("aid esperada", p.Aid(), 2);
-    retro_assert(p.Aid() == np.Aid() && p.Aid() == 2);
-    retro_assert(p.IsReply() == np.IsReply() && p.IsReply());
-    retro_assert(p.Timestamp() == np.Timestamp() && p.Timestamp() == 50);
-    retro_assert(strcmp((const char *)p.Data(), (const char *)np.Data()) == 0 && strcmp((const char *)p.Data(), teste) == 0);
-    std::vector<uint8_t> npBytes = np.ToBuf();
-    printBuf(buf, p.Length() + MelonDsDs::HeaderSize);
-    printBuf((const char *)npBytes.data(), np.Length() + MelonDsDs::HeaderSize);
-    retro_assert(memcmp(buf, (const char *)npBytes.data(), p.Length() + MelonDsDs::HeaderSize) == 0);
-}
-
 PUBLIC_SYMBOL void retro_init(void) {
 #ifdef HAVE_TRACY
     tracy::StartupProfiler();
@@ -116,7 +79,6 @@ PUBLIC_SYMBOL void retro_init(void) {
     memset(MelonDsDs::CoreStateBuffer.data(), 0, MelonDsDs::CoreStateBuffer.size());
     new(&MelonDsDs::CoreStateBuffer) MelonDsDs::CoreState(); // placement-new the CoreState
     retro_assert(MelonDsDs::Core.IsInitialized());
-    testPacket();
 }
 
 PUBLIC_SYMBOL bool retro_load_game(const struct retro_game_info *info) {

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -326,15 +326,15 @@ void Platform::WriteFirmware(const Firmware& firmware, u32 writeoffset, u32 writ
     MelonDsDs::Core.WriteFirmware(firmware, writeoffset, writelen);
 }
 
-extern "C" void MelonDsDs::MpStarted(uint16_t client_id, retro_netpacket_send_t send_fn, retro_netpacket_poll_receive_t poll_receive_fn) {
+extern "C" void MelonDsDs::MpStarted(uint16_t client_id, retro_netpacket_send_t send_fn, retro_netpacket_poll_receive_t poll_receive_fn) noexcept {
     MelonDsDs::Core.MpStarted(send_fn, poll_receive_fn);
 }
 
-extern "C" void MelonDsDs::MpReceived(const void* buf, size_t len, uint16_t client_id) {
+extern "C" void MelonDsDs::MpReceived(const void* buf, size_t len, uint16_t client_id) noexcept {
     MelonDsDs::Core.MpPacketReceived(buf, len);
 }
 
-extern "C" void MelonDsDs::MpStopped() {
+extern "C" void MelonDsDs::MpStopped() noexcept {
     MelonDsDs::Core.MpStopped();
 }
 

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -338,14 +338,13 @@ extern "C" void MelonDsDs::MpStopped() {
     MelonDsDs::Core.MpStopped();
 }
 
-int DeconstructPacket(u8 *data, u64 *timestamp, std::optional<MelonDsDs::Packet> o_p) {
+int DeconstructPacket(u8 *data, u64 *timestamp, const std::optional<MelonDsDs::Packet> &o_p) {
     if (!o_p.has_value()) {
         return 0;
     }
-    MelonDsDs::Packet p = o_p.value();
-    memcpy(data, p.Data(), p.Length());
-    *timestamp = p.Timestamp();
-    return p.Length();
+    memcpy(data, o_p->Data(), o_p->Length());
+    *timestamp = o_p->Timestamp();
+    return o_p->Length();
 }
 
 int Platform::MP_SendPacket(u8* data, int len, u64 timestamp, void*) {
@@ -386,7 +385,7 @@ u16 Platform::MP_RecvReplies(u8* packets, u64 timestamp, u16 aidmask, void*) {
         if(!o_p.has_value()) {
             return ret;
         }
-        MelonDsDs::Packet p = o_p.value();
+        MelonDsDs::Packet p = std::move(o_p).value();
         if(p.Timestamp() < (timestamp - 32)) {
             continue;
         }

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -387,40 +387,33 @@ int DeconstructPacket(u8 *data, u64 *timestamp, std::optional<MelonDsDs::Packet>
 }
 
 int Platform::MP_SendPacket(u8* data, int len, u64 timestamp, void*) {
-    retro::debug("sending command with timestamp {}", timestamp);
     return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false)) ? len : 0;
 }
 
 int Platform::MP_RecvPacket(u8* data, u64* timestamp, void*) {
-    //retro::debug("receiving packet");
     std::optional<MelonDsDs::Packet> o_p = MelonDsDs::Core.MpNextPacket();
     return DeconstructPacket(data, timestamp, o_p);
 }
 
 int Platform::MP_SendCmd(u8* data, int len, u64 timestamp, void*) {
-    retro::debug("sending command with timestamp {}", timestamp);
     return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false)) ? len : 0;
 }
 
 int Platform::MP_SendReply(u8 *data, int len, u64 timestamp, u16 aid, void*) {
     retro_assert(aid < 16);
-    retro::debug("sending reply to aid {} with timestamp {}", timestamp, aid);
     return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, aid, true)) ? len : 0;
 }
 
 int Platform::MP_SendAck(u8* data, int len, u64 timestamp, void*) {
-    retro::debug("sending ack with timestamp {}", timestamp);
     return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, 0, false)) ? len : 0;
 }
 
 int Platform::MP_RecvHostPacket(u8* data, u64 * timestamp, void*) {
-    retro::debug("receiving host packet");
     std::optional<MelonDsDs::Packet> o_p = MelonDsDs::Core.MpNextPacketBlock();
     return DeconstructPacket(data, timestamp, o_p);
 }
 
 u16 Platform::MP_RecvReplies(u8* packets, u64 timestamp, u16 aidmask, void*) {
-    retro::debug("RecvReplies called with mask {}", ((int)aidmask));
     if(!MelonDsDs::Core.MpActive()) {
         return 0;
     }

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -364,7 +364,10 @@ int Platform::MP_SendReply(u8 *data, int len, u64 timestamp, u16 aid, void*) {
     // aid is always less than 16,
     // otherwise sending a 16-bit wide aidmask in RecvReplies wouldn't make sense,
     // and neither would this line[1] from melonDS itself.
+    // A blog post from melonDS[2] from 2017 also confirms that
+    // "each client is given an ID from 1 to 15"
     // [1] https://github.com/melonDS-emu/melonDS/blob/817b409ec893fb0b2b745ee18feced08706419de/src/net/LAN.cpp#L1074
+    // [2] https://melonds.kuribo64.net/comments.php?id=25
     retro_assert(aid < 16);
     return MelonDsDs::Core.MpSendPacket(MelonDsDs::Packet(data, len, timestamp, aid, true)) ? len : 0;
 }

--- a/src/libretro/libretro.hpp
+++ b/src/libretro/libretro.hpp
@@ -40,6 +40,9 @@ namespace MelonDsDs {
     extern "C" void HardwareContextReset() noexcept;
     extern "C" void HardwareContextDestroyed() noexcept;
     extern "C" bool UpdateOptionVisibility() noexcept;
+    extern "C" void MpStarted(uint16_t client_id, retro_netpacket_send_t send_fn, retro_netpacket_poll_receive_t poll_receive_fn);
+    extern "C" void MpReceived(const void* buf, size_t len, uint16_t client_id);
+    extern "C" void MpStopped();
 }
 
 #endif //MELONDS_DS_LIBRETRO_HPP

--- a/src/libretro/libretro.hpp
+++ b/src/libretro/libretro.hpp
@@ -40,9 +40,9 @@ namespace MelonDsDs {
     extern "C" void HardwareContextReset() noexcept;
     extern "C" void HardwareContextDestroyed() noexcept;
     extern "C" bool UpdateOptionVisibility() noexcept;
-    extern "C" void MpStarted(uint16_t client_id, retro_netpacket_send_t send_fn, retro_netpacket_poll_receive_t poll_receive_fn);
-    extern "C" void MpReceived(const void* buf, size_t len, uint16_t client_id);
-    extern "C" void MpStopped();
+    extern "C" void MpStarted(uint16_t client_id, retro_netpacket_send_t send_fn, retro_netpacket_poll_receive_t poll_receive_fn) noexcept;
+    extern "C" void MpReceived(const void* buf, size_t len, uint16_t client_id) noexcept;
+    extern "C" void MpStopped() noexcept;
 }
 
 #endif //MELONDS_DS_LIBRETRO_HPP

--- a/src/libretro/net/mp.cpp
+++ b/src/libretro/net/mp.cpp
@@ -12,10 +12,6 @@ uint64_t swapToNetwork(uint64_t n) {
     return swap_if_little64(n);
 }
 
-uint64_t getTimeUs() {
-    return 0;
-}
-
 Packet Packet::parsePk(const void *buf, uint64_t len) {
     // Necessary because arithmetic on void* is forbidden
     const char *indexableBuf = (const char *)buf;

--- a/src/libretro/net/mp.cpp
+++ b/src/libretro/net/mp.cpp
@@ -16,7 +16,7 @@ Packet Packet::parsePk(const void *buf, uint64_t len) {
     // Necessary because arithmetic on void* is forbidden
     const char *indexableBuf = (const char *)buf;
     const char *data = indexableBuf + HeaderSize;
-    retro_assert(len > HeaderSize);
+    retro_assert(len >= HeaderSize);
     size_t dataLen = len - HeaderSize;
     uint64_t timestamp = swapToNetwork(*(const uint64_t*)(indexableBuf));
     uint8_t aid = *(const uint8_t*)(indexableBuf + 8);

--- a/src/libretro/net/mp.cpp
+++ b/src/libretro/net/mp.cpp
@@ -7,7 +7,6 @@
 using namespace MelonDsDs;
 
 constexpr long RECV_TIMEOUT_MS = 25;
-constexpr long STALE_PACKET_TIMEOUT_US = 16'000;
 
 uint64_t swapToNetwork(uint64_t n) {
     return swap_if_little64(n);
@@ -30,8 +29,7 @@ Packet::Packet(const void *data, uint64_t len, uint64_t timestamp, uint8_t aid, 
     _data((unsigned char*)data, (unsigned char*)data + len),
     _timestamp(timestamp),
     _aid(aid),
-    _isReply(isReply),
-    _recvTime(std::clock()){
+    _isReply(isReply){
 }
 
 std::vector<uint8_t> Packet::ToBuf() const {
@@ -43,10 +41,6 @@ std::vector<uint8_t> Packet::ToBuf() const {
     ret.push_back(_isReply);
     ret.insert(ret.end(), _data.begin(), _data.end());
     return ret;
-}
-
-uint64_t Packet::TimeDeltaUs() const noexcept {
-    return (std::clock() - _recvTime) * 1'000'000 / CLOCKS_PER_SEC;
 }
 
 bool MpState::IsReady() const noexcept {
@@ -75,16 +69,9 @@ std::optional<Packet> MpState::NextPacket() noexcept {
     if(receivedPackets.empty()) {
         return std::nullopt;
     } else {
-        while(!receivedPackets.empty()) {
-            Packet p = receivedPackets.front();
-            receivedPackets.pop();
-            if(STALE_PACKET_TIMEOUT_US != 0 && p.TimeDeltaUs() > STALE_PACKET_TIMEOUT_US) {
-                retro::info("Dropping stale packet, delta is {}", p.TimeDeltaUs());
-                continue;
-            }
-            return p;
-        }
-        return std::nullopt;
+        Packet p = receivedPackets.front();
+        receivedPackets.pop();
+        return p;
     }
 }
 

--- a/src/libretro/net/mp.cpp
+++ b/src/libretro/net/mp.cpp
@@ -20,16 +20,31 @@ Packet Packet::parsePk(const void *buf, uint64_t len) {
     size_t dataLen = len - HeaderSize;
     uint64_t timestamp = swapToNetwork(*(const uint64_t*)(indexableBuf));
     uint8_t aid = *(const uint8_t*)(indexableBuf + 8);
-    uint8_t isReply = *(const uint8_t*)(indexableBuf + 9);
-    retro_assert(isReply == 1 || isReply == 0);
-    return Packet(data, dataLen, timestamp, aid, isReply == 1);
+    uint8_t type = *(const uint8_t*)(indexableBuf + 9);
+    // type 2 means cmd frame
+    // type 1 means reply frame
+    // type 0 means anything else
+    retro_assert(type == 2 || type == 1 || type == 0);
+    Packet::Type pkType;
+    switch (type) {
+        case 0:
+            pkType = Other;
+            break;
+        case 1:
+            pkType = Reply;
+            break;
+        case 2:
+            pkType = Cmd;
+            break;
+    }
+    return Packet(data, dataLen, timestamp, aid, pkType);
 }
 
-Packet::Packet(const void *data, uint64_t len, uint64_t timestamp, uint8_t aid, bool isReply) :
+Packet::Packet(const void *data, uint64_t len, uint64_t timestamp, uint8_t aid, Packet::Type type) :
     _data((unsigned char*)data, (unsigned char*)data + len),
     _timestamp(timestamp),
     _aid(aid),
-    _isReply(isReply){
+    _type(type){
 }
 
 std::vector<uint8_t> Packet::ToBuf() const {
@@ -38,7 +53,19 @@ std::vector<uint8_t> Packet::ToBuf() const {
     uint64_t netTimestamp = swapToNetwork(_timestamp);
     ret.insert(ret.end(), (const char *)&netTimestamp, ((const char *)&netTimestamp) + sizeof(uint64_t));
     ret.push_back(_aid);
-    ret.push_back(_isReply);
+    uint8_t numericalType = 0;
+    switch(_type) {
+        case Other:
+            numericalType = 0;
+            break;
+        case Reply:
+            numericalType = 1;
+            break;
+        case Cmd:
+            numericalType = 2;
+            break;
+    }
+    ret.push_back(numericalType);
     ret.insert(ret.end(), _data.begin(), _data.end());
     return ret;
 }
@@ -55,9 +82,14 @@ void MpState::SetPollFn(retro_netpacket_poll_receive_t pollFn) noexcept {
     _pollFn = pollFn;
 }
 
-void MpState::PacketReceived(const void *buf, size_t len) noexcept {
+void MpState::PacketReceived(const void *buf, size_t len, uint16_t client_id) noexcept {
     retro_assert(IsReady());
-    receivedPackets.push(Packet::parsePk(buf, len));
+    Packet p = Packet::parsePk(buf, len);
+    if(p.PacketType() == Packet::Type::Cmd) {
+        _hostId = client_id;
+        //retro::debug("Host client id is {}", client_id);
+    }
+    receivedPackets.push(std::move(p));
 }
 
 std::optional<Packet> MpState::NextPacket() noexcept {
@@ -92,9 +124,16 @@ std::optional<Packet> MpState::NextPacketBlock() noexcept {
     return std::nullopt;
 }
 
-void MpState::SendPacket(const Packet &p) const noexcept {
+void MpState::SendPacket(const Packet &p) noexcept {
     retro_assert(IsReady());
-    _sendFn(RETRO_NETPACKET_UNSEQUENCED | RETRO_NETPACKET_UNRELIABLE | RETRO_NETPACKET_FLUSH_HINT, p.ToBuf().data(), p.Length() + HeaderSize, RETRO_NETPACKET_BROADCAST);
+    uint16_t dest = RETRO_NETPACKET_BROADCAST;
+    if(p.PacketType() == Packet::Type::Cmd) {
+        _hostId = std::nullopt;
+    }
+    if(p.PacketType() == Packet::Type::Reply && _hostId.has_value()) {
+        dest = _hostId.value();
+    }
+    _sendFn(RETRO_NETPACKET_UNSEQUENCED | RETRO_NETPACKET_UNRELIABLE | RETRO_NETPACKET_FLUSH_HINT, p.ToBuf().data(), p.Length() + HeaderSize, dest);
 }
 
 

--- a/src/libretro/net/mp.cpp
+++ b/src/libretro/net/mp.cpp
@@ -1,0 +1,122 @@
+#include "mp.hpp"
+#include <libretro.h>
+#include <retro_assert.h>
+#define TIMEOUT_FOR_POLL 16
+using namespace MelonDsDs;
+
+uint64_t swapToNetwork(uint64_t n) {
+#ifdef BIG_ENDIAN
+    return n;
+#else
+    char *d = (char*)&n;
+    uint64_t ret;
+    char *r = (char*)&ret;
+    r[7] = d[0];
+    r[6] = d[1];
+    r[5] = d[2];
+    r[4] = d[3];
+    r[3] = d[4];
+    r[2] = d[5];
+    r[1] = d[6];
+    r[0] = d[7];
+    return ret;
+#endif
+}
+
+Packet Packet::parsePk(const void *buf, uint64_t len) {
+    // Necessary because arithmetic on void* is forbidden
+    const char *indexableBuf = (const char *)buf;
+    const char *data = indexableBuf + HeaderSize;
+    retro_assert(len > HeaderSize);
+    size_t dataLen = len - HeaderSize;
+    uint64_t timestamp = swapToNetwork(*(const uint64_t*)(indexableBuf));
+    uint8_t aid = *(const uint8_t*)(indexableBuf + 4);
+    uint8_t isReply = *(const uint8_t*)(indexableBuf + 5);
+    retro_assert(isReply == 1 || isReply == 0);
+    return Packet(data, dataLen, timestamp, aid, isReply == 1);
+}
+
+Packet::Packet(const void *data, uint64_t len, uint64_t timestamp, uint8_t aid, bool isReply) {
+    // Necessary because arithmetic on void* is forbidden
+    const char *indexableData = (const char *)data;
+    _buf.reserve(HeaderSize + len);
+    // We use network byte order (big endian)
+    _buf.push_back(swapToNetwork(timestamp));
+    _buf.push_back(aid);
+    _buf.push_back(isReply ? 1 : 0);
+    _buf.insert(_buf.end(), indexableData, indexableData + len);
+}
+
+uint64_t Packet::Timestamp() {
+    return swapToNetwork(*(const uint64_t*)(_buf.data()));
+}
+
+uint8_t Packet::Aid() {
+    return *(const uint8_t*)(_buf.data() + 4);
+}
+
+bool Packet::IsReply() {
+    return *(const uint8_t*)(_buf.data() + 5) == 1;
+}
+
+const void *Packet::Data() {
+    return _buf.data() + HeaderSize;
+}
+
+uint64_t Packet::Length() {
+    return _buf.size() - HeaderSize;
+}
+
+const void *Packet::ToBuf() {
+    return _buf.data();
+}
+
+bool MpState::IsReady() {
+    return _sendFn != nullptr && _pollFn != nullptr;
+}
+
+void MpState::SetSendFn(retro_netpacket_send_t sendFn) {
+    _sendFn = sendFn;
+}
+
+void MpState::SetPollFn(retro_netpacket_poll_receive_t pollFn) {
+    _pollFn = pollFn;
+}
+
+void MpState::PacketReceived(const void *buf, size_t len) {
+    receivedPackets.push(Packet::parsePk(buf, len));
+}
+
+std::optional<Packet> MpState::NextPacket() {
+    if(receivedPackets.empty()) {
+        return std::nullopt;
+    } else {
+        Packet p = receivedPackets.front();
+        receivedPackets.pop();
+        return p;
+    }
+}
+
+std::optional<Packet> MpState::NextPacketBlock() {
+    if (receivedPackets.empty()) {
+        int i;
+        for(i = 0; i < TIMEOUT_FOR_POLL; i++) {
+            _pollFn();
+            if(!receivedPackets.empty()) {
+                break;
+            }
+        }
+        if(i == TIMEOUT_FOR_POLL) {
+            return std::nullopt;
+        }
+    }
+    Packet p = receivedPackets.front();
+    receivedPackets.pop();
+    return p;
+}
+
+void MpState::SendPacket(Packet p) {
+    _sendFn(RETRO_NETPACKET_UNRELIABLE | RETRO_NETPACKET_UNSEQUENCED, p.ToBuf(), p.Length() + HeaderSize, RETRO_NETPACKET_BROADCAST);
+}
+
+

--- a/src/libretro/net/mp.cpp
+++ b/src/libretro/net/mp.cpp
@@ -85,6 +85,8 @@ std::optional<Packet> MpState::NextPacketBlock() noexcept {
                 return NextPacket();
             }
         }
+    } else {
+        return NextPacket();
     }
     retro::debug("Timeout while waiting for packet");
     return std::nullopt;

--- a/src/libretro/net/mp.cpp
+++ b/src/libretro/net/mp.cpp
@@ -95,11 +95,6 @@ std::optional<Packet> MpState::NextPacket() {
     } else {
         Packet p = receivedPackets.front();
         receivedPackets.pop();
-        retro::debug("Delivering packet of size {}", p.Length());
-        if (p.Length() > 11) {
-            retro::debug("tenth byte is {}", (int)(((const char *)p.Data())[10]));
-            retro::debug("eleventh byte is {}", (int)(((const char *)p.Data())[11]));
-        }
         return p;
     }
 }

--- a/src/libretro/net/mp.hpp
+++ b/src/libretro/net/mp.hpp
@@ -19,9 +19,12 @@ public:
     const void *Data();
     uint64_t Length();
 
-    const void *ToBuf();
+    std::vector<uint8_t> ToBuf();
 private:
-    std::vector<uint8_t> _buf;
+    uint64_t _timestamp;
+    uint8_t _aid;
+    bool _isReply;
+    std::vector<uint8_t> _data;
 };
 
 class MpState {

--- a/src/libretro/net/mp.hpp
+++ b/src/libretro/net/mp.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <cstdint>
 #include <queue>
 #include <optional>

--- a/src/libretro/net/mp.hpp
+++ b/src/libretro/net/mp.hpp
@@ -1,0 +1,41 @@
+#include <cstdint>
+#include <queue>
+#include <optional>
+#include <vector>
+#include <libretro.h>
+
+namespace MelonDsDs {
+// timestamp, aid, and isReply, respectively.
+constexpr size_t HeaderSize = sizeof(uint64_t) + sizeof(uint8_t) + sizeof(uint8_t);
+
+class Packet {
+public:
+    static Packet parsePk(const void *buf, uint64_t len);
+    explicit Packet(const void *data, uint64_t len, uint64_t timestamp, uint8_t aid, bool isReply);
+    
+    uint64_t Timestamp();
+    uint8_t Aid();
+    bool IsReply();
+    const void *Data();
+    uint64_t Length();
+    
+    const void *ToBuf();
+private:
+    std::vector<uint8_t> _buf;
+};
+
+class MpState {
+public:
+    void PacketReceived(const void *buf, size_t len);
+    void SetSendFn(retro_netpacket_send_t sendFn);
+    void SetPollFn(retro_netpacket_poll_receive_t pollFn);
+    bool IsReady();
+    void SendPacket(Packet p);
+    std::optional<Packet> NextPacket();
+    std::optional<Packet> NextPacketBlock();
+private:
+    retro_netpacket_send_t _sendFn;
+    retro_netpacket_poll_receive_t _pollFn;
+    std::queue<Packet> receivedPackets;
+};
+}

--- a/src/libretro/net/mp.hpp
+++ b/src/libretro/net/mp.hpp
@@ -4,7 +4,6 @@
 #include <optional>
 #include <vector>
 #include <libretro.h>
-#include <ctime>
 
 namespace MelonDsDs {
 // timestamp, aid, and isReply, respectively.
@@ -30,7 +29,6 @@ public:
     [[nodiscard]] uint64_t Length() const noexcept {
         return _data.size();
     };
-    [[nodiscard]] uint64_t TimeDeltaUs() const noexcept;
 
     std::vector<uint8_t> ToBuf() const;
 private:
@@ -38,7 +36,6 @@ private:
     uint8_t _aid;
     bool _isReply;
     std::vector<uint8_t> _data;
-    std::clock_t _recvTime;
 };
 
 class MpState {

--- a/src/libretro/net/mp.hpp
+++ b/src/libretro/net/mp.hpp
@@ -12,13 +12,13 @@ class Packet {
 public:
     static Packet parsePk(const void *buf, uint64_t len);
     explicit Packet(const void *data, uint64_t len, uint64_t timestamp, uint8_t aid, bool isReply);
-    
+
     uint64_t Timestamp();
     uint8_t Aid();
     bool IsReply();
     const void *Data();
     uint64_t Length();
-    
+
     const void *ToBuf();
 private:
     std::vector<uint8_t> _buf;

--- a/src/libretro/net/mp.hpp
+++ b/src/libretro/net/mp.hpp
@@ -14,13 +14,23 @@ public:
     static Packet parsePk(const void *buf, uint64_t len);
     explicit Packet(const void *data, uint64_t len, uint64_t timestamp, uint8_t aid, bool isReply);
 
-    uint64_t Timestamp();
-    uint8_t Aid();
-    bool IsReply();
-    const void *Data();
-    uint64_t Length();
+    [[nodiscard]] uint64_t Timestamp() const noexcept {
+        return _timestamp;
+    };
+    [[nodiscard]] uint8_t Aid() const noexcept {
+        return _aid;
+    };
+    [[nodiscard]] bool IsReply() const noexcept {
+        return _isReply;
+    };
+    [[nodiscard]] const void *Data() const noexcept {
+        return _data.data();
+    };
+    [[nodiscard]] uint64_t Length() const noexcept {
+        return _data.size();
+    };
 
-    std::vector<uint8_t> ToBuf();
+    std::vector<uint8_t> ToBuf() const;
 private:
     uint64_t _timestamp;
     uint8_t _aid;
@@ -30,13 +40,13 @@ private:
 
 class MpState {
 public:
-    void PacketReceived(const void *buf, size_t len);
-    void SetSendFn(retro_netpacket_send_t sendFn);
-    void SetPollFn(retro_netpacket_poll_receive_t pollFn);
-    bool IsReady();
-    void SendPacket(Packet p);
-    std::optional<Packet> NextPacket();
-    std::optional<Packet> NextPacketBlock();
+    void PacketReceived(const void *buf, size_t len) noexcept;
+    void SetSendFn(retro_netpacket_send_t sendFn) noexcept;
+    void SetPollFn(retro_netpacket_poll_receive_t pollFn) noexcept;
+    bool IsReady() const noexcept;
+    void SendPacket(const Packet &p) const noexcept;
+    std::optional<Packet> NextPacket() noexcept;
+    std::optional<Packet> NextPacketBlock() noexcept;
 private:
     retro_netpacket_send_t _sendFn;
     retro_netpacket_poll_receive_t _pollFn;

--- a/src/libretro/net/mp.hpp
+++ b/src/libretro/net/mp.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 #include <libretro.h>
+#include <ctime>
 
 namespace MelonDsDs {
 // timestamp, aid, and isReply, respectively.
@@ -29,6 +30,7 @@ public:
     [[nodiscard]] uint64_t Length() const noexcept {
         return _data.size();
     };
+    [[nodiscard]] uint64_t TimeDeltaUs() const noexcept;
 
     std::vector<uint8_t> ToBuf() const;
 private:
@@ -36,6 +38,7 @@ private:
     uint8_t _aid;
     bool _isReply;
     std::vector<uint8_t> _data;
+    std::clock_t _recvTime;
 };
 
 class MpState {

--- a/src/libretro/platform/mp.cpp
+++ b/src/libretro/platform/mp.cpp
@@ -29,9 +29,8 @@ void MelonDsDs::CoreState::MpStarted(retro_netpacket_send_t send, retro_netpacke
 }
 
 void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len) {
-    retro_assert(_mpState.IsReady());
     _mpState.PacketReceived(buf, len);
-    retro::debug("Got packet of size {}", len);
+    retro::debug("Got packet from libretro of size {}", len);
 }
 
 void MelonDsDs::CoreState::MpStopped() {
@@ -40,16 +39,30 @@ void MelonDsDs::CoreState::MpStopped() {
     retro::info("Stopping multiplayer on libretro side");
 }
 
-void MelonDsDs::CoreState::MpSendPacket(MelonDsDs::Packet p) {
+bool MelonDsDs::CoreState::MpSendPacket(MelonDsDs::Packet p) {
+    if(!_mpState.IsReady()) {
+        return false;
+    }
     _mpState.SendPacket(p);
+    return true;
 }
 
 std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacket() {
+    if(!_mpState.IsReady()) {
+        return std::nullopt;
+    }
     return _mpState.NextPacket();
 }
 
 std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacketBlock() {
+    if(!_mpState.IsReady()) {
+        return std::nullopt;
+    }
     return _mpState.NextPacketBlock();
+}
+
+bool MelonDsDs::CoreState::MpActive() {
+    return _mpState.IsReady();
 }
 
 // Not much we can do in Begin and End
@@ -60,4 +73,5 @@ void Platform::MP_Begin(void*) {
 void Platform::MP_End(void*) {
     retro::info("Ending multiplayer on DS side");
 }
+
 

--- a/src/libretro/platform/mp.cpp
+++ b/src/libretro/platform/mp.cpp
@@ -15,6 +15,7 @@
 */
 
 #include <Platform.h>
+#include "tracy.hpp"
 #include "core/core.hpp"
 #include "environment.hpp"
 #include <fmt/base.h>
@@ -23,22 +24,26 @@
 using namespace melonDS;
 
 void MelonDsDs::CoreState::MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive) noexcept {
+    ZoneScopedN(TracyFunction);
     _mpState.SetSendFn(send);
     _mpState.SetPollFn(poll_receive);
     retro::info("Starting multiplayer on libretro side");
 }
 
 void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len) noexcept {
+    ZoneScopedN(TracyFunction);
     _mpState.PacketReceived(buf, len);
 }
 
 void MelonDsDs::CoreState::MpStopped() noexcept {
+    ZoneScopedN(TracyFunction);
     _mpState.SetSendFn(nullptr);
     _mpState.SetPollFn(nullptr);
     retro::info("Stopping multiplayer on libretro side");
 }
 
 bool MelonDsDs::CoreState::MpSendPacket(const MelonDsDs::Packet &p) const noexcept {
+    ZoneScopedN(TracyFunction);
     if(!_mpState.IsReady()) {
         return false;
     }
@@ -47,6 +52,7 @@ bool MelonDsDs::CoreState::MpSendPacket(const MelonDsDs::Packet &p) const noexce
 }
 
 std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacket() noexcept {
+    ZoneScopedN(TracyFunction);
     if(!_mpState.IsReady()) {
         return std::nullopt;
     }
@@ -54,6 +60,7 @@ std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacket() noexcept {
 }
 
 std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacketBlock() noexcept {
+    ZoneScopedN(TracyFunction);
     if(!_mpState.IsReady()) {
         return std::nullopt;
     }
@@ -66,9 +73,11 @@ bool MelonDsDs::CoreState::MpActive() const noexcept {
 
 // Not much we can do in Begin and End
 void Platform::MP_Begin(void*) {
+    ZoneScopedN(TracyFunction);
     retro::info("Starting multiplayer on DS side");
 }
 
 void Platform::MP_End(void*) {
+    ZoneScopedN(TracyFunction);
     retro::info("Ending multiplayer on DS side");
 }

--- a/src/libretro/platform/mp.cpp
+++ b/src/libretro/platform/mp.cpp
@@ -22,23 +22,23 @@
 
 using namespace melonDS;
 
-void MelonDsDs::CoreState::MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive) {
+void MelonDsDs::CoreState::MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive) noexcept {
     _mpState.SetSendFn(send);
     _mpState.SetPollFn(poll_receive);
     retro::info("Starting multiplayer on libretro side");
 }
 
-void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len) {
+void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len) noexcept {
     _mpState.PacketReceived(buf, len);
 }
 
-void MelonDsDs::CoreState::MpStopped() {
+void MelonDsDs::CoreState::MpStopped() noexcept {
     _mpState.SetSendFn(nullptr);
     _mpState.SetPollFn(nullptr);
     retro::info("Stopping multiplayer on libretro side");
 }
 
-bool MelonDsDs::CoreState::MpSendPacket(MelonDsDs::Packet p) {
+bool MelonDsDs::CoreState::MpSendPacket(const MelonDsDs::Packet &p) const noexcept {
     if(!_mpState.IsReady()) {
         return false;
     }
@@ -46,21 +46,21 @@ bool MelonDsDs::CoreState::MpSendPacket(MelonDsDs::Packet p) {
     return true;
 }
 
-std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacket() {
+std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacket() noexcept {
     if(!_mpState.IsReady()) {
         return std::nullopt;
     }
     return _mpState.NextPacket();
 }
 
-std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacketBlock() {
+std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacketBlock() noexcept {
     if(!_mpState.IsReady()) {
         return std::nullopt;
     }
     return _mpState.NextPacketBlock();
 }
 
-bool MelonDsDs::CoreState::MpActive() {
+bool MelonDsDs::CoreState::MpActive() const noexcept {
     return _mpState.IsReady();
 }
 

--- a/src/libretro/platform/mp.cpp
+++ b/src/libretro/platform/mp.cpp
@@ -30,9 +30,9 @@ void MelonDsDs::CoreState::MpStarted(retro_netpacket_send_t send, retro_netpacke
     retro::info("Starting multiplayer on libretro side");
 }
 
-void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len) noexcept {
+void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len, uint16_t client_id) noexcept {
     ZoneScopedN(TracyFunction);
-    _mpState.PacketReceived(buf, len);
+    _mpState.PacketReceived(buf, len, client_id);
 }
 
 void MelonDsDs::CoreState::MpStopped() noexcept {
@@ -42,7 +42,7 @@ void MelonDsDs::CoreState::MpStopped() noexcept {
     retro::info("Stopping multiplayer on libretro side");
 }
 
-bool MelonDsDs::CoreState::MpSendPacket(const MelonDsDs::Packet &p) const noexcept {
+bool MelonDsDs::CoreState::MpSendPacket(const MelonDsDs::Packet &p) noexcept {
     ZoneScopedN(TracyFunction);
     if(!_mpState.IsReady()) {
         return false;

--- a/src/libretro/platform/mp.cpp
+++ b/src/libretro/platform/mp.cpp
@@ -15,41 +15,49 @@
 */
 
 #include <Platform.h>
-
-//! Local multiplayer is not implemented in melonDS DS.
+#include "core/core.hpp"
+#include "environment.hpp"
+#include <fmt/base.h>
+#include <retro_assert.h>
 
 using namespace melonDS;
 
+void MelonDsDs::CoreState::MpStarted(retro_netpacket_send_t send, retro_netpacket_poll_receive_t poll_receive) {
+    _mpState.SetSendFn(send);
+    _mpState.SetPollFn(poll_receive);
+    retro::info("Starting multiplayer on libretro side");
+}
+
+void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len) {
+    retro_assert(_mpState.IsReady());
+    _mpState.PacketReceived(buf, len);
+    retro::debug("Got packet of size {}", len);
+}
+
+void MelonDsDs::CoreState::MpStopped() {
+    _mpState.SetSendFn(nullptr);
+    _mpState.SetPollFn(nullptr);
+    retro::info("Stopping multiplayer on libretro side");
+}
+
+void MelonDsDs::CoreState::MpSendPacket(MelonDsDs::Packet p) {
+    _mpState.SendPacket(p);
+}
+
+std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacket() {
+    return _mpState.NextPacket();
+}
+
+std::optional<MelonDsDs::Packet> MelonDsDs::CoreState::MpNextPacketBlock() {
+    return _mpState.NextPacketBlock();
+}
+
+// Not much we can do in Begin and End
 void Platform::MP_Begin(void*) {
+    retro::info("Starting multiplayer on DS side");
 }
 
 void Platform::MP_End(void*) {
+    retro::info("Ending multiplayer on DS side");
 }
 
-int Platform::MP_SendPacket(u8*, int, u64, void*) {
-    return 0;
-}
-
-int Platform::MP_RecvPacket(u8*, u64*, void*) {
-    return 0;
-}
-
-int Platform::MP_SendCmd(u8*, int, u64, void*) {
-    return 0;
-}
-
-int Platform::MP_SendReply(u8*, int, u64, u16, void*) {
-    return 0;
-}
-
-int Platform::MP_SendAck(u8*, int, u64, void*) {
-    return 0;
-}
-
-int Platform::MP_RecvHostPacket(u8*, u64 *, void*) {
-    return 0;
-}
-
-u16 Platform::MP_RecvReplies(u8*, u64, u16, void*) {
-    return 0;
-}

--- a/src/libretro/platform/mp.cpp
+++ b/src/libretro/platform/mp.cpp
@@ -30,7 +30,6 @@ void MelonDsDs::CoreState::MpStarted(retro_netpacket_send_t send, retro_netpacke
 
 void MelonDsDs::CoreState::MpPacketReceived(const void *buf, size_t len) {
     _mpState.PacketReceived(buf, len);
-    retro::debug("Got packet from libretro of size {}", len);
 }
 
 void MelonDsDs::CoreState::MpStopped() {

--- a/src/libretro/platform/mp.cpp
+++ b/src/libretro/platform/mp.cpp
@@ -73,5 +73,3 @@ void Platform::MP_Begin(void*) {
 void Platform::MP_End(void*) {
     retro::info("Ending multiplayer on DS side");
 }
-
-


### PR DESCRIPTION
This patch adds support for emulated local (Wi-Fi) multiplayer using libretro's [netpacket API](https://github.com/libretro/RetroArch/blob/900ec71cba1720105f55e08231b750762800de7f/libretro-common/include/libretro.h#L2500), which allows a core to send and receive arbitrary data packets across the network. In RetroArch, this can be done by using the same interface used for netplay.
Unfortunately, due to the DS's tight latency requirements for local networks, it only works for good LAN connections on a few games. I managed to play Pokémon HeartGold between my phone (connected to a WiFi AP very close by) and my PC (wired), for example. On an emulated connection, the same game worked with 8ms ping and 3% packet loss, but it could get rather laggy at times.
Thanks to @JesseTG for helping me with this.