### PR TITLE
cmake: fix build

### DIFF
--- a/cmake/libslirp.cmake
+++ b/cmake/libslirp.cmake
@@ -15,7 +15,6 @@ target_include_directories(slirp PUBLIC
 )
 target_include_directories(slirp SYSTEM PUBLIC
     "${CMAKE_SOURCE_DIR}/src/glib-stub"
-    "${libretro-common_SOURCE_DIR}/include"
 )
 
 check_type_size("void*" SIZEOF_VOID_P BUILTIN_TYPES_ONLY)
@@ -65,3 +64,5 @@ endif()
 if (APPLE)
     target_link_libraries(slirp PRIVATE resolv)
 endif()
+
+target_link_libraries(slirp PRIVATE libretro-common)


### PR DESCRIPTION
The slirp library includes `<compat/strl.h>` but never defines `HAVE_STRL`. On the other hand `libretro-common` may be compiled with `HAVE_STRL` and may rely on the system strlcat/strlcpy functions. This lead to link error because `libretro-common` is compiled without `compat/compat_strl.c` while `slirp` try to use libretro-common strlcat/strlcpy functions.

Use `target_link_libraries` instead of only `target_include_directories`, to transmit the definitions of `libretro-common` to `slirp`.