### PR TITLE
Avoid redundant set_rumble_state(0, 0) calls when idle

### DIFF
--- a/.github/workflows/check-urls.yaml
+++ b/.github/workflows/check-urls.yaml
@@ -22,4 +22,4 @@ jobs:
           print_all: false
           timeout: 10
           retry_count: 3
-          exclude_patterns: http://nus.cdn.t.shop.nintendowifi.net/ccs/download/%08x%08x/tmd,http://www.gnu.org/licenses/
+          exclude_patterns: http://nus.cdn.t.shop.nintendowifi.net/ccs/download/%08x%08x/tmd,http://www.gnu.org/licenses/,https://problemkaputt.de/gbatek.htm#dsisdmmcdsiwarefilesfromnintendosserver

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -203,6 +203,7 @@ jobs:
             -Wno-deprecated \
             -DCMAKE_BUILD_TYPE="${{ inputs.cmake-config }}" \
             -DTRACY_ENABLE="${{ env.TRACY_ENABLE }}" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             ${{ inputs.cmake-args }}
 
       - name: Configure (With Test Suite)
@@ -226,6 +227,7 @@ jobs:
             -DGBA_ROM="${{ env.TESTFILE_DIR }}/${{ secrets.GBA_ROM }}" \
             -DGBA_SRAM="${{ env.TESTFILE_DIR }}/${{ secrets.GBA_SRAM }}" \
             -DMELONDSDS_INTERNAL_VENV=OFF \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             ${{ inputs.cmake-args }}
 
       - name: Build

--- a/src/libretro/input/rumble.cpp
+++ b/src/libretro/input/rumble.cpp
@@ -53,10 +53,13 @@ retro::task::TaskSpec RumbleState::RumbleTask() noexcept {
                 last_frame_time = US_PER_FRAME;
             }
 
+            bool was_rumbling = _rumbleTimeout > 0us;
             _rumbleTimeout -= std::chrono::microseconds(static_cast<int>(last_frame_time->count() * RUMBLE_DECAY));
             if (_rumbleTimeout <= 0us) {
                 _rumbleTimeout = 0us;
-                retro::set_rumble_state(0, 0);
+                if (was_rumbling) {
+                    retro::set_rumble_state(0, 0);
+                }
             }
         },
         nullptr,


### PR DESCRIPTION
RumbleTask runs every frame (ASAP scheduling), and when _rumbleTimeout has already reached zero, the task still calls retro::set_rumble_state(0, 0) on every frame. On Linux, this goes through the evdev/haptic driver and may carry per-call syscall overhead.

This adds a check so that set_rumble_state(0, 0) is only called once on the frame where the timeout actually expires, rather than on every subsequent idle frame.

I haven't been able to test this on hardware, but the change is conservative — it just skips redundant calls when rumble is already inactive. Either this helps with the performance regression in #282, or it has no observable effect. It shouldn't be possible for this to make things worse.

Relates to #282.