### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-cmake-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-cmake-x86.yml'
@@ -75,6 +79,20 @@ libretro-build-linux-x64:
     CC: /usr/bin/gcc-12
     CXX: /usr/bin/g++-12
     CXXFLAGS: -Wno-deprecated-declarations # Deprecation warnings aren't helpful on the libretro Gitlab
+    CORE_ARGS: -Wno-deprecated
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-defs
+  # Same as the x64 job: the default image's GCC is too old for this core's
+  # C++20 usage, so use the backports image and GCC 12.
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-aarch64-ubuntu:backports
+  variables:
+    CC: /usr/bin/gcc-12
+    CXX: /usr/bin/g++-12
+    CXXFLAGS: -Wno-deprecated-declarations
     CORE_ARGS: -Wno-deprecated
 
 # MacOS 64-bit


### PR DESCRIPTION
## What

Adds a **Linux aarch64** libretro build to CI, matching the existing `android-arm64-v8a` job (this core already builds and JITs on ARM64).

- `.gitlab-ci.yml`: add the `/linux-cmake-aarch64.yml` include + a `libretro-build-linux-aarch64` job.
- The job mirrors `libretro-build-linux-x64`: it uses the `…-aarch64-ubuntu:backports` image with GCC 12, because this core's C++20 usage needs a newer compiler than the default aarch64 image ships. (Please confirm that image tag exists on the buildbot — it's the aarch64 analogue of the amd64 backports image the x64 job already uses.)

## Testing

Built the core for **aarch64** natively (GCC 15.2, CMake Release) and ran the resulting `melondsds_libretro.so` in RetroArch 1.22 on an aarch64 device: it loads and boots a retail NDS ROM to gameplay (FreeBIOS fallback, software renderer). ELF confirmed `aarch64`.
