### PR TITLE
ci: fix broken aarch64 job (drop nonexistent linux-cmake-aarch64.yml include)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,10 +23,6 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
-  # Linux ARM 64-bit
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/linux-cmake-aarch64.yml'
-
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-cmake-x86.yml'


### PR DESCRIPTION
Follow-up to #309. The aarch64 job it added references a non-existent CI template include, which makes the libretro GitLab mirror reject the whole pipeline:

```
Unable to create pipeline
Project `libretro-infrastructure/ci-templates` file `linux-cmake-aarch64.yml` does not exist!
```

There is no separate `linux-cmake-aarch64.yml` template — the `.libretro-linux-cmake-aarch64` job class is provided by the already-included `/linux-cmake.yml`. This drops the bogus `include:` entry; the `libretro-build-linux-aarch64` job (extending `.libretro-linux-cmake-aarch64`) is unchanged and now resolves.

Verified against other CMake cores that build for Linux aarch64 (e.g. `libretro/swanstation`, `libretro/ps2`), which include only `/linux-cmake.yml` and extend `.libretro-linux-cmake-aarch64` the same way.