### PR TITLE
ci: drop the nonexistent aarch64 backports image tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,8 @@ libretro-build-linux-aarch64:
   extends:
     - .libretro-linux-cmake-aarch64
     - .core-defs
-  # Same as the x64 job: the default image's GCC is too old for this core's
-  # C++20 usage, so use the backports image and GCC 12.
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-aarch64-ubuntu:backports
+  # No image override here: unlike the x64 image, the aarch64 one already ships
+  # GCC 12 and a current CMake, so the template's default image is what we want.
   variables:
     CC: /usr/bin/gcc-12
     CXX: /usr/bin/g++-12


### PR DESCRIPTION
Follow-up to #311. The aarch64 job now gets created, but it still cannot start:

```
WARNING: Failed to pull image with policy "always": ... failed to resolve reference
"git.libretro.com:5050/libretro-infrastructure/libretro-build-aarch64-ubuntu:backports": not found
ERROR: Job failed: failed to pull image ... with specified policies [always if-not-present]
```

([pipeline 93530, job 1926467](https://git.libretro.com/libretro/melonds-ds/-/jobs/1926467) — the whole log is 18 lines, it dies in `prepare_executor`.)

`libretro-build-aarch64-ubuntu` only publishes `:latest` and `:main`; there is no `:backports` tag. I added that override in #309 by analogy with the x64 job, which was my mistake.

It also isn't needed. On amd64, GCC 12 lives in a separate `Dockerfile.backports`, which is why that job needs the tag. The aarch64 image installs the same toolchain in its **main** Dockerfile:

```dockerfile
# Install newer GCC from Ubuntu toolchain PPA
RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
	apt-get update && \
	apt-get install -y gcc-12 g++-12 && \
	update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 && ...

# Install newer CMake from Kitware
RUN ... echo 'deb ... https://apt.kitware.com/ubuntu/ bionic main' ... && apt-get install -y cmake
```

So `:latest` (the default from `.libretro-linux-cmake-aarch64` in `linux-cmake.yml`) already provides `/usr/bin/gcc-12` and CMake 3.25.2, which covers this core's C++20 usage and its `cmake_minimum_required(VERSION 3.19)`. This PR drops the override and keeps the `CC`/`CXX` variables.

The other red jobs on `dev` (`libretro-build-windows-x64`, `android-*`) are unrelated to CI configuration — they're green on `main` and fail on `dev` after the recent melonDS bumps (`MEM_*_PLACEHOLDER` undeclared with the image's mingw-w64 headers, and `undefined symbol: __emutls_v._ZN7melonDS3NDS7CurrentE` when linking on Android). Happy to look into those separately if useful.
