### PR TITLE
Add per-speed audio volume options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ a design goal is to avoid a 2.x release for as long as possible.
 
 ## [Unreleased]
 
+### Added
+
+- Added core options for the audio volume while the frontend runs the core off-speed:
+  Fast-Forward Volume, Slow Motion Volume and Rewind Volume
+  (`melonds_audio_speedup_volume`, `melonds_audio_slowmo_volume`, `melonds_audio_rewind_volume`).
+  Each ranges from 0% (muted) to 100% (unchanged, the default).
+
 ### Fixed
 
 - Fixed the error screen not honoring the screen layout settings

--- a/src/libretro/CMakeLists.txt
+++ b/src/libretro/CMakeLists.txt
@@ -9,6 +9,15 @@ else ()
     set(LIBRARY_TYPE MODULE)
 endif ()
 
+# Mirror melonDS's LTO settings so our objects and melonDS's are both bitcode.
+# (Mixed LTO/non-LTO breaks emulated-TLS symbols like NDS::Current on Android/MinGW.)
+if (ENABLE_LTO_RELEASE)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+endif ()
+if (ENABLE_LTO)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()
+
 add_library(melondsds_libretro ${LIBRARY_TYPE}
     buffer.cpp
     buffer.hpp

--- a/src/libretro/config/config.cpp
+++ b/src/libretro/config/config.cpp
@@ -652,6 +652,27 @@ static void MelonDsDs::config::ParseAudioOptions(CoreConfig& config) noexcept {
         retro::warn("Failed to get value for {}; defaulting to {}", AUDIO_INTERPOLATION, values::DISABLED);
         config.SetInterpolation(AudioInterpolation::None);
     }
+
+    if (optional<unsigned> value = ParseIntegerInRange<unsigned>(get_variable(SPEEDUP_VOLUME), 0u, 100u)) {
+        config.SetSpeedupVolume(*value);
+    } else {
+        retro::warn("Failed to get value for {}; defaulting to 100", SPEEDUP_VOLUME);
+        config.SetSpeedupVolume(100);
+    }
+
+    if (optional<unsigned> value = ParseIntegerInRange<unsigned>(get_variable(SLOWMO_VOLUME), 0u, 100u)) {
+        config.SetSlowmoVolume(*value);
+    } else {
+        retro::warn("Failed to get value for {}; defaulting to 100", SLOWMO_VOLUME);
+        config.SetSlowmoVolume(100);
+    }
+
+    if (optional<unsigned> value = ParseIntegerInRange<unsigned>(get_variable(REWIND_VOLUME), 0u, 100u)) {
+        config.SetRewindVolume(*value);
+    } else {
+        retro::warn("Failed to get value for {}; defaulting to 100", REWIND_VOLUME);
+        config.SetRewindVolume(100);
+    }
 }
 
 static void MelonDsDs::config::ParseNetworkOptions(CoreConfig& config) noexcept {

--- a/src/libretro/config/config.hpp
+++ b/src/libretro/config/config.hpp
@@ -83,6 +83,15 @@ namespace MelonDsDs {
         [[nodiscard]] melonDS::AudioInterpolation Interpolation() const noexcept { return _interpolation; }
         void SetInterpolation(melonDS::AudioInterpolation interpolation) noexcept { _interpolation = interpolation; }
 
+        [[nodiscard]] unsigned SpeedupVolume() const noexcept { return _speedupVolume; }
+        void SetSpeedupVolume(unsigned volume) noexcept { _speedupVolume = volume; }
+
+        [[nodiscard]] unsigned SlowmoVolume() const noexcept { return _slowmoVolume; }
+        void SetSlowmoVolume(unsigned volume) noexcept { _slowmoVolume = volume; }
+
+        [[nodiscard]] unsigned RewindVolume() const noexcept { return _rewindVolume; }
+        void SetRewindVolume(unsigned volume) noexcept { _rewindVolume = volume; }
+
         [[nodiscard]] MelonDsDs::AlarmMode AlarmMode() const noexcept { return _alarmMode; }
         void SetAlarmMode(MelonDsDs::AlarmMode alarmMode) noexcept { _alarmMode = alarmMode; }
 
@@ -429,6 +438,9 @@ namespace MelonDsDs {
         MelonDsDs::MicInputMode _micInputMode = *ParseMicInputMode(config::definitions::MicInput.default_value);
         melonDS::AudioBitDepth _bitDepth;
         melonDS::AudioInterpolation _interpolation;
+        unsigned _speedupVolume = 100;
+        unsigned _slowmoVolume = 100;
+        unsigned _rewindVolume = 100;
         MelonDsDs::AlarmMode _alarmMode;
         optional<unsigned> _alarmHour;
         optional<unsigned> _alarmMinute;

--- a/src/libretro/config/constants.hpp
+++ b/src/libretro/config/constants.hpp
@@ -46,6 +46,9 @@ namespace MelonDsDs::config {
         static constexpr const char *const AUDIO_INTERPOLATION = "melonds_audio_interpolation";
         static constexpr const char *const MIC_INPUT = "melonds_mic_input";
         static constexpr const char *const MIC_INPUT_BUTTON = "melonds_mic_input_active";
+        static constexpr const char *const SPEEDUP_VOLUME = "melonds_audio_speedup_volume";
+        static constexpr const char *const SLOWMO_VOLUME = "melonds_audio_slowmo_volume";
+        static constexpr const char *const REWIND_VOLUME = "melonds_audio_rewind_volume";
     }
 
     namespace cpu {

--- a/src/libretro/config/definitions.hpp
+++ b/src/libretro/config/definitions.hpp
@@ -39,6 +39,9 @@ namespace MelonDsDs::config::definitions {
         MicInputButton,
         BitDepth,
         AudioInterpolation,
+        SpeedupVolume,
+        SlowmoVolume,
+        RewindVolume,
 
 #ifdef JIT_ENABLED
         JitEnabled,

--- a/src/libretro/config/definitions/audio.hpp
+++ b/src/libretro/config/definitions/audio.hpp
@@ -113,5 +113,74 @@ namespace MelonDsDs::config::definitions {
         BitDepth,
         AudioInterpolation,
     };
+
+    constexpr retro_core_option_v2_definition SpeedupVolume {
+        config::audio::SPEEDUP_VOLUME,
+        "Fast-Forward Volume",
+        nullptr,
+        "The volume to use while the frontend runs the core faster than normal, "
+        "whether by fast-forwarding or by not throttling at all.\n"
+        "\n"
+        "100% leaves the audio untouched.\n"
+        "0% silences it.",
+        nullptr,
+        config::audio::CATEGORY,
+        {
+            {"0", "0% (Muted)"},
+            {"10", "10%"},
+            {"25", "25%"},
+            {"50", "50%"},
+            {"75", "75%"},
+            {"100", "100%"},
+            {nullptr, nullptr},
+        },
+        "100",
+    };
+
+    constexpr retro_core_option_v2_definition SlowmoVolume {
+        config::audio::SLOWMO_VOLUME,
+        "Slow Motion Volume",
+        nullptr,
+        "The volume to use while the frontend runs the core in slow motion.\n"
+        "\n"
+        "100% leaves the audio untouched.\n"
+        "0% silences it.",
+        nullptr,
+        config::audio::CATEGORY,
+        {
+            {"0", "0% (Muted)"},
+            {"10", "10%"},
+            {"25", "25%"},
+            {"50", "50%"},
+            {"75", "75%"},
+            {"100", "100%"},
+            {nullptr, nullptr},
+        },
+        "100",
+    };
+
+    constexpr retro_core_option_v2_definition RewindVolume {
+        config::audio::REWIND_VOLUME,
+        "Rewind Volume",
+        nullptr,
+        "The volume to use while the frontend is rewinding.\n"
+        "\n"
+        "Rewound audio is played backwards, so a reduced volume is often more pleasant.\n"
+        "\n"
+        "100% leaves the audio untouched.\n"
+        "0% silences it.",
+        nullptr,
+        config::audio::CATEGORY,
+        {
+            {"0", "0% (Muted)"},
+            {"10", "10%"},
+            {"25", "25%"},
+            {"50", "50%"},
+            {"75", "75%"},
+            {"100", "100%"},
+            {nullptr, nullptr},
+        },
+        "100",
+    };
 }
 #endif //MELONDS_DS_AUDIO_HPP

--- a/src/libretro/core/core.cpp
+++ b/src/libretro/core/core.cpp
@@ -16,7 +16,9 @@
 
 #include "core.hpp"
 
+#include <algorithm>
 #include <charconv>
+#include <optional>
 #include <DSi.h>
 
 #include <retro_assert.h>
@@ -29,6 +31,7 @@
 #include "console/dsi.hpp"
 #include "constants.hpp"
 #include "../config/console.hpp"
+#include "../environment.hpp"
 #include "../exceptions.hpp"
 #include "../format.hpp"
 #include "../info.hpp"
@@ -199,7 +202,7 @@ void MelonDsDs::CoreState::Run() noexcept {
         }
 
         _renderState.Render(nds, _inputState, Config, _screenLayout);
-        RenderAudio(*Console);
+        RenderAudio(*Console, Config);
 
         retro::task::check();
     }
@@ -288,13 +291,87 @@ void MelonDsDs::CoreState::Reset() {
 }
 
 
-void MelonDsDs::CoreState::RenderAudio(melonDS::NDS& nds) noexcept {
+namespace {
+    // The volume percentage for the frontend's current throttle mode, or 100 when
+    // it's at normal speed or reports nothing we can act on.
+    unsigned ThrottleVolume(const MelonDsDs::CoreConfig& config) noexcept {
+        // Nothing to override, so don't ask the frontend anything.
+        if (config.SpeedupVolume() == 100 && config.SlowmoVolume() == 100 && config.RewindVolume() == 100)
+            return 100;
+
+        if (std::optional<retro_throttle_state> throttle = retro::get_throttle_state()) {
+            switch (throttle->mode) {
+                case RETRO_THROTTLE_FAST_FORWARD:
+                case RETRO_THROTTLE_UNBLOCKED:
+                    return config.SpeedupVolume();
+                case RETRO_THROTTLE_SLOW_MOTION:
+                    return config.SlowmoVolume();
+                case RETRO_THROTTLE_REWINDING:
+                    return config.RewindVolume();
+                default:
+                    return 100;
+            }
+        }
+
+        // GET_THROTTLE_STATE and GET_FASTFORWARDING are both experimental calls;
+        // fall back to the latter, coarser one when the former isn't available.
+        // A bool can't tell slow motion or rewind apart, so only speed-up is reachable.
+        if (std::optional<bool> fastforwarding = retro::is_fastforwarding()) {
+            return *fastforwarding ? config.SpeedupVolume() : 100;
+        }
+
+        // Neither environment call is available, so there's nothing to override.
+        return 100;
+    }
+}
+
+void MelonDsDs::CoreState::RenderAudio(melonDS::NDS& nds, const CoreConfig& config) noexcept {
     ZoneScopedN(TracyFunction);
     int16_t audio_buffer[0x1000]; // 4096 samples == 2048 stereo frames
     uint32_t size = std::min(nds.SPU.GetOutputSize(), static_cast<int>(sizeof(audio_buffer) / (2 * sizeof(int16_t))));
     // Ensure that we don't overrun the buffer
 
     size_t read = nds.SPU.ReadOutput(audio_buffer, size);
+    // read is a count of stereo frames, so the buffer holds read*2 samples.
+
+    if (read > 0) {
+        // Only query the frontend, and only update _lastAudioVolume, when there's
+        // audio to act on; an empty buffer has nothing to ramp and nothing to remember.
+        unsigned volume = ThrottleVolume(config);
+        unsigned prevVolume = _lastAudioVolume;
+        if (prevVolume == 100 && volume == 100) {
+            // Nothing to do; leave the buffer as the SPU wrote it.
+        } else if (prevVolume == volume) {
+            // Steady state at some other volume, so apply it flat.
+            if (volume == 0) {
+                std::fill_n(audio_buffer, read * 2, int16_t {0});
+            } else {
+                for (size_t i = 0; i < read * 2; ++i) {
+                    audio_buffer[i] = static_cast<int16_t>(
+                        (static_cast<int32_t>(audio_buffer[i]) * static_cast<int32_t>(volume)) / 100
+                    );
+                }
+            }
+        } else {
+            // The volume changed, so ramp across this buffer rather than snapping to it,
+            // which would click. Both channels of a frame share a gain, so interpolate
+            // per frame instead of per sample.
+            int32_t prev = static_cast<int32_t>(prevVolume);
+            int32_t cur = static_cast<int32_t>(volume);
+            int32_t span = cur - prev;
+            auto frameCount = static_cast<int32_t>(read);
+            for (size_t frame = 0; frame < read; ++frame) {
+                int32_t gain = prev + (span * static_cast<int32_t>(frame)) / frameCount;
+                int16_t& left = audio_buffer[frame * 2];
+                int16_t& right = audio_buffer[frame * 2 + 1];
+                left = static_cast<int16_t>((static_cast<int32_t>(left) * gain) / 100);
+                right = static_cast<int16_t>((static_cast<int32_t>(right) * gain) / 100);
+            }
+        }
+
+        _lastAudioVolume = volume;
+    }
+
     retro::audio_sample_batch(audio_buffer, read);
 }
 

--- a/src/libretro/core/core.hpp
+++ b/src/libretro/core/core.hpp
@@ -125,7 +125,7 @@ namespace MelonDsDs {
             const melonDS::NDSHeader& header,
             int type
         ) noexcept;
-        [[gnu::hot]] static void RenderAudio(melonDS::NDS& nds) noexcept;
+        [[gnu::hot]] void RenderAudio(melonDS::NDS& nds, const CoreConfig& config) noexcept;
         [[gnu::cold]] bool InitErrorScreen(const config_exception& e) noexcept;
         [[gnu::cold]] void RenderErrorScreen() noexcept;
         [[gnu::cold]] void InitContent(unsigned type, std::span<const retro_game_info> game);
@@ -170,6 +170,14 @@ namespace MelonDsDs {
         bool _ndsSramInstalled = false;
         bool _deferredInitializationPending = false;
         uint32_t _flushTaskId = 0;
+        // The target volume of the last audio buffer that carried samples (read > 0),
+        // so RenderAudio can ramp into a change; a ramp's final frame falls slightly
+        // short of this value, since it's the target rather than the gain actually
+        // applied. A member and not a function-local static: CoreState is placement-new'd
+        // into a single static buffer at retro_init and destroyed at retro_deinit, so a
+        // static here would persist across that cycle and leak a stale volume into the
+        // next session.
+        unsigned _lastAudioVolume = 100;
     };
 }
 #endif //MELONDSDS_CORE_HPP

--- a/test/python/test_options.py
+++ b/test/python/test_options.py
@@ -129,3 +129,33 @@ def test_options_visibility_update_callback(session: SessionFactory, nds_rom: Pa
     with session(nds_rom) as emulator:
         assert emulator.options.update_display_callback
         assert emulator.options.update_display_callback.callback
+
+
+@pytest.mark.nds_rom
+@pytest.mark.parametrize(
+    "key",
+    [
+        "melonds_audio_speedup_volume",
+        "melonds_audio_slowmo_volume",
+        "melonds_audio_rewind_volume",
+    ],
+)
+def test_declares_speed_volume_options(
+    session: SessionFactory, nds_rom: Path, key: str
+) -> None:
+    """Each per-speed volume option is declared, defaults to 100, and is readable."""
+    with session(nds_rom) as emulator:
+        definitions = emulator.options.definitions
+        assert key.encode() in definitions
+
+        definition = definitions[key.encode()]
+        assert definition.default_value == b"100"
+
+        values = {value.value for value in definition.values if value.value}
+        assert values == {b"0", b"10", b"25", b"50", b"75", b"100"}
+
+        get_option = emulator.get_proc_address(
+            "libretropy_get_option", TypedFunctionPointer[c_char_p, [CStringArg]]
+        )
+        assert get_option is not None
+        assert get_option(key.encode()) == b"100"

--- a/test/python/test_speed_volume.py
+++ b/test/python/test_speed_volume.py
@@ -1,0 +1,270 @@
+"""Per-speed audio volume: the volume applied for each frontend throttle mode."""
+
+from __future__ import annotations
+
+from array import array
+from pathlib import Path
+
+import pytest
+from libretro import Session, ThrottleMode
+from libretro.api.timing import retro_throttle_state
+from libretro.drivers import DefaultTimingDriver
+
+from melondsds import SessionFactory
+
+#: Frames to run before sampling audio; matches test_av.test_generates_audio.
+FRAMES = 300
+
+#: Upper bound on frames to search for sustained audio before triggering a mid-session
+#: transition, in _run_until_sustained_audio below. Generous rather than tuned to any
+#: one ROM: test/README.md promises "the tests don't assume any particular ROM," so a
+#: ROM with a long silent intro, or one that waits at a title screen, must be searched
+#: past rather than assumed away with a fixed frame count.
+RAMP_WARMUP_FRAME_CAP = 3000
+
+#: Minimum ratio between the transition buffer's opening-tenth peak and its
+#: closing-tenth peak, in test_transition_ramps_instead_of_snapping below. See that
+#: test for why this threshold was chosen.
+RAMP_SHAPE_MIN_FALL_RATIO = 5
+
+
+def _timing(mode: ThrottleMode) -> DefaultTimingDriver:
+    """A timing driver that reports ``mode`` to the core."""
+    return DefaultTimingDriver(retro_throttle_state(mode, 0.0), 60.0)
+
+
+def _run_until_sustained_audio(emulator: Session, buffer: array) -> None:
+    """
+    Run frames until two consecutive buffers are non-silent, up to
+    ``RAMP_WARMUP_FRAME_CAP`` frames total.
+
+    Two in a row, rather than one, makes it likely audio is genuinely sustained (e.g.
+    background music) rather than a single transient blip: the caller needs the
+    *next* buffer after this to carry audio too, to capture a real transition.
+
+    Skips the test, rather than failing it, if the cap is reached without finding
+    sustained audio: the ROM may have a long silent intro or sit at a title screen,
+    and the suite promises not to assume otherwise (see test/README.md).
+    """
+    consecutive_audible_buffers = 0
+    for _ in range(RAMP_WARMUP_FRAME_CAP):
+        before = len(buffer)
+        emulator.run()
+        if any(sample != 0 for sample in buffer[before:]):
+            consecutive_audible_buffers += 1
+            if consecutive_audible_buffers >= 2:
+                return
+        else:
+            consecutive_audible_buffers = 0
+
+    pytest.skip(
+        f"the test ROM produced no sustained audio within {RAMP_WARMUP_FRAME_CAP} frames"
+    )
+
+
+def _peak(session: SessionFactory, rom: Path, mode: ThrottleMode, **options: str) -> int:
+    """Peak absolute sample value after running ``FRAMES`` frames under ``mode``."""
+    variables = {key.encode(): value.encode() for key, value in options.items()}
+    with session(rom, options=variables, timing=_timing(mode)) as emulator:
+        for _ in range(FRAMES):
+            emulator.run()
+
+        buffer = emulator.audio.buffer
+        assert buffer is not None
+        assert len(buffer) > 0
+        return max(abs(sample) for sample in buffer)
+
+
+@pytest.mark.nds_rom
+def test_full_volume_is_unchanged(session: SessionFactory, nds_rom: Path) -> None:
+    """At 100% the speed-up volume leaves audio alone."""
+    baseline = _peak(session, nds_rom, ThrottleMode.NONE)
+    speeding = _peak(
+        session, nds_rom, ThrottleMode.FAST_FORWARD, melonds_audio_speedup_volume="100"
+    )
+    assert speeding == baseline
+
+
+@pytest.mark.nds_rom
+def test_zero_volume_is_silent(session: SessionFactory, nds_rom: Path) -> None:
+    """At 0% the speed-up volume silences audio entirely."""
+    # Negative control: without the override, this ROM produces audible output,
+    # so a silent result below is the option's doing, not a silent ROM.
+    assert _peak(session, nds_rom, ThrottleMode.NONE) > 0
+
+    assert (
+        _peak(session, nds_rom, ThrottleMode.FAST_FORWARD, melonds_audio_speedup_volume="0")
+        == 0
+    )
+
+
+@pytest.mark.nds_rom
+@pytest.mark.parametrize("mode", [ThrottleMode.FAST_FORWARD, ThrottleMode.UNBLOCKED])
+def test_speedup_volume_scales(
+    session: SessionFactory, nds_rom: Path, mode: ThrottleMode
+) -> None:
+    """Both speed-up modes halve the peak at 50%."""
+    baseline = _peak(session, nds_rom, ThrottleMode.NONE)
+    halved = _peak(session, nds_rom, mode, melonds_audio_speedup_volume="50")
+
+    # Integer scaling and rounding make this approximate, not exact.
+    assert halved == pytest.approx(baseline // 2, rel=0.02, abs=2)
+
+
+@pytest.mark.nds_rom
+@pytest.mark.parametrize(
+    ("mode", "option"),
+    [
+        (ThrottleMode.SLOW_MOTION, "melonds_audio_slowmo_volume"),
+        (ThrottleMode.REWINDING, "melonds_audio_rewind_volume"),
+    ],
+)
+def test_each_mode_uses_its_own_option(
+    session: SessionFactory, nds_rom: Path, mode: ThrottleMode, option: str
+) -> None:
+    """Slow motion and rewind read their own option, not the speed-up one."""
+    # Silencing the *other* two options must not affect this mode.
+    others = {
+        key: "0"
+        for key in (
+            "melonds_audio_speedup_volume",
+            "melonds_audio_slowmo_volume",
+            "melonds_audio_rewind_volume",
+        )
+        if key != option
+    }
+    assert _peak(session, nds_rom, mode, **others) > 0
+
+    # Silencing this mode's own option must silence it.
+    assert _peak(session, nds_rom, mode, **{option: "0"}) == 0
+
+
+@pytest.mark.nds_rom
+@pytest.mark.parametrize("mode", [ThrottleMode.NONE, ThrottleMode.VSYNC, ThrottleMode.FRAME_STEPPING])
+def test_normal_speed_ignores_every_option(
+    session: SessionFactory, nds_rom: Path, mode: ThrottleMode
+) -> None:
+    """At normal speed no override applies, whatever the options say."""
+    baseline = _peak(session, nds_rom, ThrottleMode.NONE)
+    muted_everywhere = _peak(
+        session,
+        nds_rom,
+        mode,
+        melonds_audio_speedup_volume="0",
+        melonds_audio_slowmo_volume="0",
+        melonds_audio_rewind_volume="0",
+    )
+    assert muted_everywhere == baseline
+
+
+@pytest.mark.nds_rom
+def test_falls_back_when_throttle_state_unsupported(
+    session: SessionFactory, nds_rom: Path
+) -> None:
+    """With neither GET_THROTTLE_STATE nor GET_FASTFORWARDING reported, no override applies."""
+    # libretro.py 0.8.3 gates GET_THROTTLE_STATE and GET_FASTFORWARDING on the same
+    # DefaultTimingDriver.throttle_state (drivers/environment/composite.py:1669,1992),
+    # so a driver that refuses one refuses both. That means this only exercises the
+    # third fallback tier in ThrottleVolume ("neither call available"); the
+    # is_fastforwarding()-returns-True tier is out of reach with this harness and is
+    # not covered anywhere in this suite.
+    no_throttle = DefaultTimingDriver(None, 60.0)
+    variables = {b"melonds_audio_speedup_volume": b"0"}
+    with session(nds_rom, options=variables, timing=no_throttle) as emulator:
+        for _ in range(FRAMES):
+            emulator.run()
+
+        buffer = emulator.audio.buffer
+        assert buffer is not None
+        assert len(buffer) > 0
+        # Neither environment call is answered, so ThrottleVolume falls all the way
+        # through to its default of 100: the override must NOT apply and audio must
+        # survive despite melonds_audio_speedup_volume="0".
+        assert any(sample != 0 for sample in buffer)
+
+
+@pytest.mark.nds_rom
+def test_out_of_range_option_falls_back_to_full_volume(
+    session: SessionFactory, nds_rom: Path
+) -> None:
+    """An out-of-range option value is rejected by ParseIntegerInRange and defaults to 100."""
+    baseline = _peak(session, nds_rom, ThrottleMode.NONE)
+    out_of_range = _peak(
+        session, nds_rom, ThrottleMode.FAST_FORWARD, melonds_audio_speedup_volume="150"
+    )
+    assert out_of_range == baseline
+
+
+@pytest.mark.nds_rom
+def test_transition_ramps_instead_of_snapping(
+    session: SessionFactory, nds_rom: Path
+) -> None:
+    """
+    The gain change on entering (or leaving) an off-speed mode is ramped across
+    one buffer instead of snapping instantly, to avoid an audible click.
+
+    ``DefaultTimingDriver.throttle_state`` is mutable, so this drives a real
+    mode change mid-session (the same thing the frontend does when the user
+    presses the fast-forward hotkey) rather than starting a fresh session
+    already in fast-forward.
+    """
+    driver = DefaultTimingDriver(retro_throttle_state(ThrottleMode.NONE, 0.0), 60.0)
+    variables = {b"melonds_audio_speedup_volume": b"0"}
+    with session(nds_rom, options=variables, timing=driver) as emulator:
+        buffer = emulator.audio.buffer
+        assert buffer is not None
+        _run_until_sustained_audio(emulator, buffer)
+
+        # Negative control: audio is actually flowing before the transition, at
+        # ThrottleMode.NONE the speed-up option has no effect (ThrottleVolume
+        # returns 100 the entire time), so a fade below is the ramp's doing,
+        # not a ROM that happened to go quiet.
+        assert any(sample != 0 for sample in buffer)
+
+        # Enter fast-forward with the speed-up volume at 0%. The volume RenderAudio
+        # has stored is still 100 from the run above, so this is a genuine 100 -> 0
+        # transition, not a session that started in fast-forward already at 0.
+        before_transition = len(buffer)
+        driver.throttle_state = retro_throttle_state(ThrottleMode.FAST_FORWARD, 0.0)
+        emulator.run()  # Exactly one retro_run() call == exactly one RenderAudio buffer.
+
+        transition_buffer = buffer[before_transition:]
+        assert len(transition_buffer) > 0
+        # A flat cut to 0% would make this buffer uniformly silent. A ramp fades it
+        # instead: the gain starts at 100 (continuous with the previous buffer) and
+        # falls from there, so this buffer must NOT be uniformly silent.
+        assert any(sample != 0 for sample in transition_buffer)
+
+        # Shape check: a ramp's gain falls *linearly* across the buffer, so its
+        # opening frames must be much louder than its closing ones. This is what
+        # actually distinguishes a ramp from a one-buffer-late snap: a broken
+        # implementation that applies the *previous* (100%) volume flat across this
+        # whole buffer, and only stores the new volume afterward, would also pass the
+        # assertion above (non-silent throughout) without ramping anything. At
+        # ~547 frames per buffer, a correct 100 -> 0 ramp's average gain across the
+        # opening tenth is ~95%, versus ~5% across the closing tenth (its very last
+        # frame lands around 1%) -- about a 19x gap by average gain, though peaks
+        # (rather than averages) move with the signal too: this test's ROM measured
+        # ~9.9x (peaks of 1599 vs 161). RAMP_SHAPE_MIN_FALL_RATIO of 5 stays below
+        # that observed value for headroom against normal signal variation, while
+        # staying far above the ~1.1x a flat, unramped buffer produced when tried;
+        # verified experimentally against both broken implementations (see
+        # review-fixes-report.md).
+        tenth = max(1, len(transition_buffer) // 10)
+        opening_peak = max(abs(sample) for sample in transition_buffer[:tenth])
+        closing_peak = max(abs(sample) for sample in transition_buffer[-tenth:])
+        assert opening_peak >= RAMP_SHAPE_MIN_FALL_RATIO * closing_peak, (
+            f"opening-tenth peak {opening_peak} was not at least "
+            f"{RAMP_SHAPE_MIN_FALL_RATIO}x the closing-tenth peak {closing_peak}; "
+            "the gain doesn't look like it ramps down across the buffer"
+        )
+
+        after_transition = len(buffer)
+        for _ in range(30):
+            emulator.run()
+
+        settled_buffer = buffer[after_transition:]
+        assert len(settled_buffer) > 0
+        # Once the one-buffer ramp has completed, the volume is flat at 0% again,
+        # same as it was before the ramp existed: fully silent.
+        assert all(sample == 0 for sample in settled_buffer)


### PR DESCRIPTION
Since one of the builds was failing the first commit here mirrors the LTO settings from upstream melonDS. Probably should be cherry-picked onto its own PR or something if you're worried about a clean history.

--------------------------------

When I started this I didn't actually realize retroarch had their own "mute when fast-fowarding" toggle, and also didn't realize that the basic mute when fast-fowarding was already merged into the main melonds project. Either way, I added a similar set of features to the core if it's desired.

This adds melonds_audio_speedup_volume, melonds_audio_slowmo_volume and melonds_audio_rewind_volume, each 0-100% defaulting to 100%, so speeding up can be quiet rather than silent and slow motion and rewind get their own levels.

<img width="1702" height="679" alt="image" src="https://github.com/user-attachments/assets/4ae7437a-edbe-4f4b-bfd4-9e8185a4c505" />

The core reads the frontend's throttle mode each frame and scales the SPU output by the matching option, ramping across a buffer when the volume changes so the transition doesn't click.

Where GET_THROTTLE_STATE isn't available it falls back to GET_FASTFORWARDING, and where neither is it does nothing; both are experimental calls. At 100% the audio path is untouched, and the throttle query is skipped entirely while all three options are left at their default.

If it's not necessary since retroarch already has the base mute on fast-forward feature that I didn't realize until I was almost done with this, then we can close this PR.